### PR TITLE
Refactor async open preparation

### DIFF
--- a/cutter2/Application/DocumentController.swift
+++ b/cutter2/Application/DocumentController.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import AVFoundation
 
 @MainActor
 class DocumentController: NSDocumentController {
@@ -25,21 +26,31 @@ class DocumentController: NSDocumentController {
         super.beginOpenPanel(openPanel, forTypes: inTypes, completionHandler: completionHandler)
     }
     
-    private func makeDocumentAsync(withContentsOf url: URL, ofType typeName: String) async throws -> NSDocument {
+    private static func prepareOpen(for url: URL) async throws -> OpenPreparation {
+        let typeName: String = try NSDocumentController.shared.typeForContents(of: url)
+        return try await Task.detached(priority: .userInitiated) { @Sendable in
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            let modificationDate = attributes[.modificationDate] as? Date
+            let movie: AVMutableMovie = AVMutableMovie(url: url, options: nil)
+            return OpenPreparation(typeName: typeName,
+                                   modificationDate: modificationDate,
+                                   movHeader: movie.movHeader)
+        }.value
+    }
+    
+    private func makeDocumentAsync(withContentsOf url: URL) async throws -> NSDocument {
         
         // Create a new document
         let document = Document()
         
         // Read the document data
-        try await document.readAsync(from: url, ofType: typeName)
+        let openPreparation = try await Self.prepareOpen(for: url)
+        try await document.readAsync(from: url, openPreparation: openPreparation)
         
         // Set the document properties
         document.fileURL = url
-        document.fileType = typeName
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        if let modificationDate = attributes[.modificationDate] as? Date {
-            document.fileModificationDate = modificationDate
-        }
+        document.fileType = openPreparation.typeName
+        document.fileModificationDate = openPreparation.modificationDate
         document.updateChangeCount(.changeCleared)
         return document
     }
@@ -54,11 +65,8 @@ class DocumentController: NSDocumentController {
             return (existingDocument, false)
         }
         
-        // Check file type
-        let typeName: String = try self.typeForContents(of: url)
-        
         // Open the document
-        let document = try await makeDocumentAsync(withContentsOf: url, ofType: typeName)
+        let document = try await makeDocumentAsync(withContentsOf: url)
         self.addDocument(document)
         
         // Display the document if requested
@@ -69,21 +77,19 @@ class DocumentController: NSDocumentController {
         return (document, true)
     }
     
-    private func makeDocumentAsync(for urlOrNil: URL?, withContentsOf contentsURL: URL, ofType typeName: String) async throws -> NSDocument {
+    private func makeDocumentAsync(for urlOrNil: URL?, withContentsOf contentsURL: URL) async throws -> NSDocument {
         
         // Create a new document
         let document = Document()
         
         // Read the document data
-        try await document.readAsync(from: contentsURL, ofType: typeName)
+        let openPreparation = try await Self.prepareOpen(for: contentsURL)
+        try await document.readAsync(from: contentsURL, openPreparation: openPreparation)
         
         // Set the document properties
         document.fileURL = urlOrNil
-        document.fileType = typeName
-        let attributes = try FileManager.default.attributesOfItem(atPath: contentsURL.path)
-        if let modificationDate = attributes[.modificationDate] as? Date {
-            document.fileModificationDate = modificationDate
-        }
+        document.fileType = openPreparation.typeName
+        document.fileModificationDate = openPreparation.modificationDate
         document.updateChangeCount(.changeReadOtherContents)
         return document
     }
@@ -98,11 +104,8 @@ class DocumentController: NSDocumentController {
             return (existingDocument, false)
         }
         
-        // Check file type
-        let typeName: String = try self.typeForContents(of: contentsURL)
-        
         // Open the document
-        let document = try await makeDocumentAsync(for: urlOrNil, withContentsOf: contentsURL, ofType: typeName)
+        let document = try await makeDocumentAsync(for: urlOrNil, withContentsOf: contentsURL)
         self.addDocument(document)
         
         // Display the document if requested

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -10,6 +10,14 @@ import Cocoa
 import AVFoundation
 import os.log
 
+/// Prepared data for async document opening.
+///
+/// This separates background I/O from MainActor state application. `DocumentController.prepareOpen`
+/// collects:
+/// - `typeName`: Document type resolved on MainActor.
+/// - `modificationDate`: File modification date for metadata updates.
+/// - `movHeader`: Movie header used to initialize MovieMutator without extra I/O.
+/// The preparation is passed into `Document.readAsync(from:openPreparation:)` during open/reopen.
 struct OpenPreparation: Sendable {
     let typeName: String
     let modificationDate: Date?

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -10,6 +10,12 @@ import Cocoa
 import AVFoundation
 import os.log
 
+struct OpenPreparation: Sendable {
+    let typeName: String
+    let modificationDate: Date?
+    let movHeader: Data?
+}
+
 /* ============================================ */
 // MARK: - File I/O Operations
 /* ============================================ */
@@ -37,11 +43,12 @@ extension Document {
     /// Custom read(from:ofType:) throws w/ async
     /// - Parameters:
     ///   - url: The location from which the document contents are read.
-    ///   - typeName: The string that identifies the document type.
-    func readAsync(from url: URL, ofType typeName: String) async throws {
+    ///   - openPreparation: Precomputed open metadata for the URL.
+    func readAsync(from url: URL, openPreparation: OpenPreparation) async throws {
         LoggingSystem.fileIO.info("Reading document from \(url.lastPathComponent, privacy: .public)")
         
         // Check UTI for AVMovie fileType
+        let typeName = openPreparation.typeName
         let fileType = AVFileType.init(rawValue: typeName)
         if AVMovie.movieTypes().contains(fileType) == false {
             let reason = "(UTI: \(typeName))"
@@ -49,22 +56,8 @@ extension Document {
             try throwError(.incompatibleFileType, reason: reason)
         }
         
-        // Extract movie header from URL
-        let header = await Task.detached {
-            let movie: AVMutableMovie = AVMutableMovie(url: url, options: nil)
-            return movie.movHeader
-        }.value
-        
-        if let header = header {
+        if let header = openPreparation.movHeader {
             // File opened successfully
-            self.fileURL = url
-            self.fileType = typeName
-            let attribute = try FileManager.default.attributesOfItem(atPath: url.path)
-            if let modificationDate = attribute[.modificationDate] as? Date {
-                self.fileModificationDate = modificationDate
-            }
-            self.updateChangeCount(.changeCleared)
-            
             // Initialize movieMutator
             let movie = AVMutableMovie(data: header)
             self.removeMutationObserver()
@@ -93,7 +86,7 @@ extension Document {
          but that method is marked with `@MainActor`, so invoking it on a background thread crashes immediately.
          
          Instead, we override `NSDocumentController`'s `openDocument()` and `reopenDocument()` methods
-         and use a custom `readAsync()` implementation to support Swift Concurrency properly.
+         and use custom `OpenPreparation` + `readAsync()` implementations to support Swift Concurrency properly.
          */
         return true
     }


### PR DESCRIPTION
   ## Summary
   - Move open-time preprocessing off MainActor via OpenPreparation and a background task.
   - Keep type resolution on MainActor and apply prepared state in open/reopen + readAsync.
   - Reduce readAsync responsibilities to state application only.

   ## Testing
   - xcodebuild test
