### PR TITLE
Adopt AsyncBridge (§10.2) and fix Swift 6 self-capture data races in MovieMutator

### DIFF
--- a/cutter2/Document/Document+ActorIsolation.swift
+++ b/cutter2/Document/Document+ActorIsolation.swift
@@ -14,20 +14,6 @@ import os.log
 // MARK: - Actor isolation
 /* ============================================ */
 
-/// A simple thread-safe container for holding mutable results captured by @Sendable closures.
-///
-/// This class uses `@unchecked Sendable` because:
-/// - Access is synchronized via a DispatchQueue in `performAsync`
-/// - The value is only written once and read once
-/// - No concurrent access occurs during normal operation
-/// - The DispatchQueue provides the necessary memory barrier
-private final class SendableBox<T> {
-    var value: T
-    init(_ value: T) { self.value = value }
-}
-
-extension SendableBox: @unchecked Sendable {}
-
 extension Document {
     
     /// Executes an asynchronous, throwing operation synchronously on a detached task.
@@ -35,62 +21,33 @@ extension Document {
     /// This method bridges async/await operations to synchronous AppKit document APIs.
     /// It is designed to be called from `nonisolated` contexts (specifically `Document.write(...)`).
     ///
-    /// **Design Rationale:**
-    /// - `Task.detached` is used because:
-    ///   - Must be called from a `nonisolated` context (no parent task to inherit from)
-    ///   - AppKit's `canAsynchronouslyWrite` already executes `write()` on a background queue
-    ///   - No task priority inheritance is needed (AppKit manages thread priority)
-    /// - Semaphore waiting is used because:
-    ///   - Must block until async operation completes (AppKit document save requires synchronous return)
-    ///   - DispatchQueue provides thread-safe result passing
-    /// - Works in conjunction with `canAsynchronouslyWrite() -> Bool { true }`
+    /// Implementation is delegated to `AsyncBridge.perform` (adopted from
+    /// `performAsync_comparison.md` §10.2). AppKit's `canAsynchronouslyWrite` executes
+    /// `write()` on a background queue, so the default `allowMainThread: false`
+    /// precondition is satisfied.
     ///
     /// - Parameter block: A closure that performs asynchronous work and may throw.
     /// - Returns: The result produced by the closure.
     /// - Throws: An error thrown by the closure.
     /// - Warning: This blocks the current thread. Do not call from the main thread.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async throws -> T) throws -> T {
-        precondition(!Thread.isMainThread, "performAsync must not be called from the main thread.")
-        let semaphore = DispatchSemaphore(value: 0)
-        let lock = DispatchQueue(label: "ResultLock")
-        let resultBox = SendableBox<Result<T, Error>?>(nil)
-        Task.detached(priority: .userInitiated) { @Sendable in
-            let taskResult: Result<T, Error>
-            do {
-                taskResult = .success(try await block())
-            } catch {
-                taskResult = .failure(error)
-            }
-            lock.sync {
-                resultBox.value = taskResult
-            }
-            semaphore.signal()
-        }
-        semaphore.wait()
-        return try lock.sync { try resultBox.value!.get() }
+        return try AsyncBridge.perform(block)
     }
     
     /// Executes an asynchronous, non-throwing operation synchronously on a detached task.
     ///
-    /// This is the non-throwing variant of `performAsync`. See the throwing version for detailed rationale.
+    /// A `() async -> T` block satisfies `() async throws -> T`, so the throwing
+    /// variant of `AsyncBridge.perform` is reused. See the throwing version for design rationale.
     ///
     /// - Parameter block: A closure that performs asynchronous work.
     /// - Returns: The result produced by the closure.
     /// - Warning: This blocks the current thread. Do not call from the main thread.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T {
-        precondition(!Thread.isMainThread, "performAsync must not be called from the main thread.")
-        let semaphore = DispatchSemaphore(value: 0)
-        let lock = DispatchQueue(label: "ResultLock")
-        let resultBox = SendableBox<T?>(nil)
-        Task.detached(priority: .userInitiated) { @Sendable in
-            let taskResult = await block()
-            lock.sync {
-                resultBox.value = taskResult
-            }
-            semaphore.signal()
+        do {
+            return try AsyncBridge.perform(block)
+        } catch {
+            fatalError("Non-throwing performAsync unexpectedly threw: \(error)")
         }
-        semaphore.wait()
-        return lock.sync { resultBox.value! }
     }
     
     /// Runs a throwing `@MainActor`-isolated closure synchronously.

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -195,11 +195,11 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoCutHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager, unowned self] (me1) in // @escaping
+        let undoCutHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             // register redo record
-            performSyncOnMainActor {
-                let redoCutHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager, unowned self] (me2) in // @escaping
-                    performSyncOnMainActor {
+            me1.performSyncOnMainActor {
+                let redoCutHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
+                    me2.performSyncOnMainActor {
                         me2.resetMarker(time, range, false)
                         me2.cutSelection(using: undoManager)
                     }
@@ -232,11 +232,11 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager, unowned self] (me1) in // @escaping
+        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             // register redo record
-            performSyncOnMainActor {
-                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[unowned undoManager, unowned self] (me2) in // @escaping
-                    performSyncOnMainActor {
+            me1.performSyncOnMainActor {
+                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[unowned undoManager] (me2) in // @escaping
+                    me2.performSyncOnMainActor {
                         me2.pasteAtInsertionTime(using: undoManager)
                     }
                 }
@@ -268,11 +268,11 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoDeleteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager, unowned self] (me1) in // @escaping
+        let undoDeleteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             // register redo record
-            performSyncOnMainActor {
-                let redoDeleteHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager, unowned self] (me2) in // @escaping
-                    performSyncOnMainActor {
+            me1.performSyncOnMainActor {
+                let redoDeleteHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
+                    me2.performSyncOnMainActor {
                         me2.resetMarker(time, range, false)
                         me2.deleteSelection(using: undoManager)
                     }

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -51,11 +51,11 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager, unowned self] (me1) in // @escaping
+        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager] (me1) in // @escaping
             // register redo replace
-            performSyncOnMainActor {
-                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[movie, unowned undoManager, unowned self] (me2) in // @escaping
-                    performSyncOnMainActor {
+            me1.performSyncOnMainActor {
+                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[movie, unowned undoManager] (me2) in // @escaping
+                    me2.performSyncOnMainActor {
                         me2.updateFormat(movie, using: undoManager)
                     }
                 }

--- a/cutter2/Utilities/AsyncBridge.swift
+++ b/cutter2/Utilities/AsyncBridge.swift
@@ -1,0 +1,121 @@
+//
+//  AsyncBridge.swift
+//  cutter2
+//
+//  Unified async-to-sync bridge adopted from performAsync_comparison.md §10.2.
+//
+
+/* This software is released under the MIT License, see LICENSE.txt. */
+
+import Foundation
+import os.lock
+
+enum PerformAsyncError: Error {
+    case timeout(TimeInterval)
+    case operationFailed(String)
+}
+
+private final class UnfairLockBox: @unchecked Sendable {
+    private var rawLock = os_unfair_lock_s()
+    
+    @inline(__always)
+    func withLock<T>(_ body: () throws -> T) throws -> T {
+        os_unfair_lock_lock(&rawLock)
+        defer { os_unfair_lock_unlock(&rawLock) }
+        return try body()
+    }
+}
+
+private final class AsyncResultBox<T>: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var value: T?
+    
+    func store(_ value: T) throws {
+        try lock.withLock { self.value = value }
+        semaphore.signal()
+    }
+    
+    func waitAndGet(timeout: TimeInterval?) throws -> T {
+        let waitResult: DispatchTimeoutResult
+        if let timeout = timeout {
+            waitResult = semaphore.wait(timeout: .now() + timeout)
+            guard case .success = waitResult else {
+                throw PerformAsyncError.timeout(timeout)
+            }
+        } else {
+            semaphore.wait()
+        }
+        
+        return try lock.withLock {
+            guard let value = value else {
+                throw PerformAsyncError.operationFailed(
+                    "Async operation failed to complete"
+                )
+            }
+            return value
+        }
+    }
+}
+
+private final class ThrowingAsyncResultBox<T>: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<T, Error>?
+    
+    func store(_ result: Result<T, Error>) throws {
+        try lock.withLock { self.result = result }
+        semaphore.signal()
+    }
+    
+    func waitAndGet(timeout: TimeInterval?) throws -> T {
+        let waitResult: DispatchTimeoutResult
+        if let timeout = timeout {
+            waitResult = semaphore.wait(timeout: .now() + timeout)
+            guard case .success = waitResult else {
+                throw PerformAsyncError.timeout(timeout)
+            }
+        } else {
+            semaphore.wait()
+        }
+        
+        return try lock.withLock {
+            guard let result = result else {
+                throw PerformAsyncError.operationFailed(
+                    "Async operation failed to complete"
+                )
+            }
+            return try result.get()
+        }
+    }
+}
+
+enum AsyncBridge {
+    
+    static func perform<T: Sendable>(
+        timeout: TimeInterval? = nil,
+        allowMainThread: Bool = false,
+        _ block: @Sendable @escaping () async throws -> T
+    ) throws -> T {
+        precondition(
+            allowMainThread || !Thread.isMainThread,
+            "AsyncBridge.perform must not be called from the main thread. Use allowMainThread: true if you understand the deadlock risk."
+        )
+        
+        let box = ThrowingAsyncResultBox<T>()
+        let task = Task.detached(priority: .userInitiated) { [box, block] in
+            do {
+                let value = try await block()
+                try box.store(.success(value))
+            } catch {
+                try? box.store(.failure(error))
+            }
+        }
+        do {
+            return try box.waitAndGet(timeout: timeout)
+        } catch {
+            task.cancel()
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the unified `AsyncBridge` from `performAsync_comparison.md` §10.2 into cutter2, and in the same series fix four Swift 6 strict-concurrency self-capture data-race warnings that were surfaced by `MovieMutator`'s undo/redo registration paths.

## Commits (2)

1. `36c2c74` — Adopt performAsync_comparison.md §10.2 unified AsyncBridge in cutter2
   - Add `cutter2/Utilities/AsyncBridge.swift` (new file)
   - Remove the inline `SendableBox` + custom implementation in `cutter2/Document/Document+ActorIsolation.swift`; replace it with thin `nonisolated` wrappers that delegate to `AsyncBridge.perform`
   - Design intent (async-to-sync bridge + main-thread call guard) is fully preserved
2. `69b5292` — Fix Swift 6 self-capture data races in MovieMutator undo/redo registration
   - Flatten the double `unowned self` capture pattern in three undo/redo handlers in `MovieMutator+Edit.swift` (cut, paste, delete) and one in `MovieMutator+Transform.swift` (update format) into a `me1.performSyncOnMainActor` / `me2.performSyncOnMainActor` shape
   - Drop the redundant `unowned self` captures; `self` now flows in through the `@Sendable` target parameter

## Verification

- Xcode Build / Analyze: SUCCEEDED, 0 warnings
- Changes are scoped and self-contained; public API semantics are unchanged (`Document.performAsync`, `MovieMutator` undo/redo registration behavior)

## Impact

- Behavior change: none
- Public signature change: none
- New file: `cutter2/Utilities/AsyncBridge.swift` (project-local; independent from the same-named files under DLABrecDL/DLAB)
