### PR TITLE
Fix H-01/H-02/H-03/H-04: concurrency contract, teardown crash hazards, and IUO cleanup

### DIFF
--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -38,7 +38,7 @@ extension Document {
             guard response == NSApplication.ModalResponse.continue else { return }
             
             Task { @MainActor in
-                guard let self else { preconditionFailure("Unexpected nil self detected.") }
+                guard let self else { return }
                 self.transcoding = true
                 self.saveTo(self)
                 self.transcoding = false

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -48,7 +48,7 @@ extension Document {
     
     internal func export(to url: URL, ofType typeName: String, preset: String) async throws {
         
-        guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
         
         // Create NSProgress with proper lifecycle management
         let progress = Progress(totalUnitCount: 100)
@@ -109,7 +109,7 @@ extension Document {
     
     internal func exportCustom(to url: URL, ofType typeName: String) async throws {
         
-        guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
         
         // Create NSProgress with proper lifecycle management
         let progress = Progress(totalUnitCount: 100)

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -112,7 +112,7 @@ extension Document {
         LoggingSystem.document.info("Saving document to \(url.lastPathComponent)")
         
         //
-        guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
         guard mutator.movieDuration() > CMTime.zero else {
             let reason = NSLocalizedString("error.reason.zero_duration_movie",
                                          comment: "Error reason when movie has zero duration")
@@ -278,7 +278,7 @@ extension Document {
     
     private func writeAsync(to url: URL, ofType typeName: String) async throws {
         
-        guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
         
         // Create NSProgress with proper lifecycle management
         let progress = Progress(totalUnitCount: 100)
@@ -369,7 +369,7 @@ extension Document {
             guard let url: URL = self.fileURL else { preconditionFailure("Unexpected nil fileURL detected.") }
             let newMovie: AVMutableMovie? = AVMutableMovie(url: url, options: nil)
             if let newMovie = newMovie {
-                guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+                guard let mutator = self.movieMutator else { return }
                 let time: CMTime = mutator.insertionTime
                 let range: CMTimeRange = mutator.selectedTimeRange
                 

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -178,7 +178,7 @@ extension Document {
         if saveOperation == .saveAsOperation, let srcURL = self.fileURL {
             Task { @Sendable @MainActor [typeName, srcURL, weak self] in // @escaping
                 
-                guard let self else { preconditionFailure("Unexpected nil self detected.") }
+                guard let self else { return }
                 let fileType: AVFileType = AVFileType.init(rawValue: typeName)
                 guard fileType == .mov else { return }
                 
@@ -245,7 +245,7 @@ extension Document {
         // Trigger long running task via global dispatch queue
         do {
             try performAsync { @Sendable [weak self] in
-                guard let self else { preconditionFailure("Unexpected nil self detected.") }
+                guard let self else { throw CocoaError(.fileWriteUnknown) }
                 
                 switch saveOperation {
                 case .saveToOperation:
@@ -365,7 +365,7 @@ extension Document {
         // SaveAs triggers internal movie refresh (to sync selfcontained <> referece movie change)
         Task { @MainActor [weak self] in
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard let url: URL = self.fileURL else { preconditionFailure("Unexpected nil fileURL detected.") }
             let newMovie: AVMutableMovie? = AVMutableMovie(url: url, options: nil)
             if let newMovie = newMovie {

--- a/cutter2/Document/Document+Observers.swift
+++ b/cutter2/Document/Document+Observers.swift
@@ -137,7 +137,7 @@ extension Document {
         
         let handler: @Sendable (Notification) -> Void = {[weak self] (notification) in // @escaping
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard
                 let mutator = performSyncOnMainActor({ self.movieMutator }),
                 let object = notification.object as? MovieMutator,

--- a/cutter2/Document/Document+SavePanel.swift
+++ b/cutter2/Document/Document+SavePanel.swift
@@ -23,7 +23,7 @@ extension Document {
     
     override func prepareSavePanel(_ savePanel: NSSavePanel) -> Bool {
         
-        guard let mutator = self.movieMutator else { preconditionFailure("Unexpected nil mutator detected.") }
+        guard let mutator = self.movieMutator else { return false }
         
         // prepare accessory view controller
         if self.accessoryVC == nil {
@@ -145,7 +145,7 @@ extension Document {
     // AccessoryViewDelegate protocol
     public func didUpdateFileType(_ fileType: AVFileType, selfContained: Bool) {
         
-        guard let savePanel = self.savePanel else { preconditionFailure("Unexpected nil savePanel detected.") }
+        guard let savePanel = self.savePanel else { return }
         savePanel.allowedContentTypes = [UTType(fileType.rawValue)!]
     }
 }

--- a/cutter2/Document/Document+SheetControl.swift
+++ b/cutter2/Document/Document+SheetControl.swift
@@ -153,8 +153,9 @@ extension Document {
     public func showErrorSheet(_ error: Error) {
         
         // Don't use NSDocument default error handling
-        guard let window = self.window else { NSSound.beep(); return }
         Task { @MainActor in
+            
+            guard let window = self.window else { NSSound.beep(); return }
             
             let alert = NSAlert(error: error)
             let err :NSError = error as NSError

--- a/cutter2/Document/Document+SheetControl.swift
+++ b/cutter2/Document/Document+SheetControl.swift
@@ -153,7 +153,7 @@ extension Document {
     public func showErrorSheet(_ error: Error) {
         
         // Don't use NSDocument default error handling
-        guard let window = self.window else { preconditionFailure("Unexpected nil window detected.") }
+        guard let window = self.window else { NSSound.beep(); return }
         Task { @MainActor in
             
             let alert = NSAlert(error: error)

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -148,7 +148,7 @@ extension Document {
         // Show CAPAR Sheet
         caparVC.beginSheetModal(for: self.window!) {[caparVC, mutator, weak self] (response) in // @escaping
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard response == .continue else { return }
             
             // Update Clap/Pasp settings
@@ -197,9 +197,9 @@ extension Document {
         
         updateRate(player, 0.0)
         let handler: @Sendable (Bool) -> Void = {[weak self, weak player, weak mutator] (finished) in // @escaping
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
-            guard let player = player else { preconditionFailure("Unexpected nil player detected.") }
-            guard let mutator = mutator else { preconditionFailure("Unexpected nil mutator detected.") }
+            guard let self else { return }
+            guard let player = player else { return }
+            guard let mutator = mutator else { return }
             performSyncOnMainActor {
                 updateRate(player, rate)
                 updateTimeline(time, range: mutator.selectedTimeRange)
@@ -248,8 +248,8 @@ extension Document {
             // seek
             let handler: @Sendable (Bool) -> Void = {[weak self, weak pv] (finished) in // @escaping
                 
-                guard let self else { preconditionFailure("Unexpected nil self detected.") }
-                guard let pv = pv else { preconditionFailure("Unexpected nil pv detected.") }
+                guard let self else { return }
+                guard let pv = pv else { return }
                 performSyncOnMainActor {
                     pv.needsDisplay = true
                 }

--- a/cutter2/Document/Document.swift
+++ b/cutter2/Document/Document.swift
@@ -278,7 +278,7 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
         
         self.closingBlock = {[obj, shouldCloseSelector, contextInfo, weak self] (flag) -> Void in // @escaping
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             function(obj, shouldCloseSelector!, self, flag, contextInfo)
         }
         

--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -61,12 +61,11 @@ extension MovieMutator {
     /// - For custom exports, both cancelExport() and cancelCustomMovie() are called
     ///
     /// **Design Notes:**
-    /// - This method is asynchronous and should be awaited to ensure proper cancellation
+    /// - This method is async due to the actor hop to MovieWriter
     /// - The writer reference is captured to avoid race conditions
-    /// - Uses structured concurrency to ensure the cancellation does not outlive the parent instance
-    ///   - Actual cancellation happens asynchronously in MovieWriter
-    ///   - Cancellation state is tracked via writeCancelled flag
-    ///   - The ongoing operation will detect cancellation and throw appropriately
+    /// - On the MovieWriter actor, cancellation is synchronous: it sets the writeCancelled
+    ///   flag and cancels the export session
+    /// - The ongoing export/write operation checks writeCancelled flag and throws OperationCancelled
     public func cancel() async {
         guard let writer = self.currentMovieWriter else { return }
         // Capture the writer reference to avoid race condition between check and use

--- a/cutter2/Models/MovieMutatorBase.swift
+++ b/cutter2/Models/MovieMutatorBase.swift
@@ -307,17 +307,10 @@ class MovieMutatorBase: NSObject {
     /// ```
     public func progressStream() -> AsyncStream<Float> {
         AsyncStream { [weak self] continuation in
-            // IMPORTANT: progressContinuation is a @MainActor-isolated property
-            // (via MovieMutator subclass). We must assign it synchronously on
-            // MainActor to ensure it's set BEFORE export operations begin.
-            // While AsyncStream.Continuation.yield() is thread-safe, the property
-            // assignment itself requires MainActor isolation.
-            if Thread.isMainThread {
+            // Assign continuation on MainActor using ActorUtilities to ensure
+            // proper isolation tracking and avoid strict concurrency warnings.
+            ActorUtilities.performSyncOnMainActor {
                 self?.progressContinuation = continuation
-            } else {
-                DispatchQueue.main.sync {
-                    self?.progressContinuation = continuation
-                }
             }
             
             continuation.onTermination = { @Sendable [weak self] _ in

--- a/cutter2/Models/SampleBufferChannel.swift
+++ b/cutter2/Models/SampleBufferChannel.swift
@@ -53,10 +53,10 @@ class SampleBufferChannel: @unchecked Sendable {
         self.completionHandler = completionHandler
         
         awInput.requestMediaDataWhenReady(on: queue) {[weak self] in // @escaping
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             if self.finished { return }
             
-            guard let delegate: SampleBufferChannelDelegate = self.delegate else { preconditionFailure("Unexpected nil delegate detected.") }
+            guard let delegate: SampleBufferChannelDelegate = self.delegate else { return }
             let arOutput: AVAssetReaderOutput = self.arOutput
             let awInput: AVAssetWriterInput = self.awInput
             
@@ -82,7 +82,7 @@ class SampleBufferChannel: @unchecked Sendable {
     public func cancel() {
         queue.async { [weak self] in
             do {
-                guard let self else { preconditionFailure("Unexpected nil self detected.") }
+                guard let self else { return }
                 self.callCompletionHandlerIfNecessary()
             }
         }

--- a/cutter2/Models/SampleBufferChannel.swift
+++ b/cutter2/Models/SampleBufferChannel.swift
@@ -56,7 +56,15 @@ class SampleBufferChannel: @unchecked Sendable {
             guard let self else { return }
             if self.finished { return }
             
-            guard let delegate: SampleBufferChannelDelegate = self.delegate else { return }
+            guard let delegate: SampleBufferChannelDelegate = self.delegate else {
+                // Delegate (typically MovieWriter actor) was deallocated mid-export.
+                // Terminate the channel by invoking the completion handler so the
+                // caller's withCheckedContinuation resumes and the task group does
+                // not deadlock. Matches the H-02(b) teardown-safety pattern
+                // applied to [weak delegate] references.
+                self.callCompletionHandlerIfNecessary()
+                return
+            }
             let arOutput: AVAssetReaderOutput = self.arOutput
             let awInput: AVAssetWriterInput = self.awInput
             

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -21,37 +21,38 @@ extension LayoutConverter {
         var pos: Set<AudioChannelLabel>?
         aclData.withUnsafeBytes { (p: UnsafeRawBufferPointer) in
             guard let baseAddress = p.baseAddress else { return }
-            // The AudioChannelLayout header occupies the first 12 bytes:
-            //   mChannelLayoutTag (UInt32) + mChannelBitmap (UInt32) + mNumberChannelDescriptions (UInt32).
-            // Note: MemoryLayout<AudioChannelLayout>.size is 32 on real platforms
-            // (the struct includes a trailing mChannelDescriptions[1] for variable-length
-            // array trick), so we use 3 * MemoryLayout<UInt32>.size to express the
-            // header-only bound instead. This lets tag/bitmap layouts (12 bytes) through
-            // while still rejecting undersized buffers. Matches L-04's commented-out
-            // precondition in LayoutConverter+LayoutData.swift:23.
-            let headerSize = 3 * MemoryLayout<UInt32>.size
-            guard p.count >= headerSize else { return }
-            // Peek at the tag without binding AudioChannelLayout (which would require
-            // the full struct size, 32 bytes). Treat the first 12 bytes as three UInt32s.
-            let tagPtr = baseAddress.assumingMemoryBound(to: AudioChannelLayoutTag.self)
-            let tag = tagPtr.pointee
-            // For kAudioChannelLayoutTag_UseChannelDescriptions, channelLabelSet reads
-            // mNumberChannelDescriptions AudioChannelDescription values (20 bytes each
-            // — Float32 label + UInt32 flags + Float32[3] coordinates) past the header.
-            // Verify the buffer holds the full size before calling.
+            // Discover layout at runtime: do not hardcode any offset or size, so
+            // the helper adapts to struct definition changes (e.g. Apple adding
+            // fields, changing padding, or redefining alignment on a future
+            // platform).
+            let descArrayOffset = MemoryLayout<AudioChannelLayout>.offset(of: \.mChannelDescriptions) ?? 0
+            let descSize = MemoryLayout<AudioChannelDescription>.size
+            let structSize = MemoryLayout<AudioChannelLayout>.size
+            // bindMemory with capacity 1 requires structSize contiguous bytes
+            // for the header read; channelLabelSet will bind the same way, so a
+            // single guard covers both.
+            guard p.count >= structSize else { return }
+            let headerPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+            let tag = headerPtr.pointee.mChannelLayoutTag
+            let descCount = Int(headerPtr.pointee.mNumberChannelDescriptions)
+            // For UseChannelDescriptions, channelLabelSet walks descCount
+            // AudioChannelDescription values starting at descArrayOffset. The
+            // first slot is already covered by structSize (the trailing
+            // mChannelDescriptions[1] inside AudioChannelLayout), so we only
+            // need to add (descCount - 1) more. For other tags, channelLabelSet
+            // only touches the header fields and structSize is sufficient.
+            let requiredSize: Int
             if tag == kAudioChannelLayoutTag_UseChannelDescriptions {
-                let descCountPtr = baseAddress
-                    .advanced(by: 2 * MemoryLayout<UInt32>.size)
-                    .assumingMemoryBound(to: UInt32.self)
-                let descCount = Int(descCountPtr.pointee)
-                let requiredSize = headerSize
-                    + max(0, descCount - 1) * MemoryLayout<AudioChannelDescription>.size
-                guard p.count >= requiredSize else { return }
+                // A UseChannelDescriptions tag with descCount == 0 is malformed
+                // (the tag promises a description array but declares it empty);
+                // reject up front to avoid a redundant 0-size check below.
+                guard descCount > 0 else { return }
+                requiredSize = structSize + (descCount - 1) * descSize
+            } else {
+                requiredSize = structSize
             }
-            // Now safe to bind for channelLabelSet (the UseChannelDescriptions
-            // branch has already verified sufficient capacity above).
-            let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-            pos = channelLabelSet(ptr)
+            guard p.count >= requiredSize else { return }
+            pos = channelLabelSet(headerPtr)
         }
         return pos
     }

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -21,6 +21,10 @@ extension LayoutConverter {
         var pos: Set<AudioChannelLabel>?
         aclData.withUnsafeBytes { (p: UnsafeRawBufferPointer) in
             guard let baseAddress = p.baseAddress else { return }
+            // Defensive: ensure the buffer is at least one AudioChannelLayout
+            // (matches the L-04 intent of the commented-out precondition
+            // in LayoutConverter+LayoutData.swift:23).
+            guard p.count >= MemoryLayout<AudioChannelLayout>.size else { return }
             let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
             pos = channelLabelSet(ptr)
         }

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -12,6 +12,22 @@ import AVFoundation
 extension LayoutConverter {
     
     /* ============================================ */
+    // MARK: - private helpers
+    /* ============================================ */
+    
+    /// Safely extracts channel label set from AudioChannelLayoutData.
+    /// Returns nil if the buffer is empty or invalid.
+    private func extractChannelLabelSet(from aclData: AudioChannelLayoutData) -> Set<AudioChannelLabel>? {
+        var pos: Set<AudioChannelLabel>?
+        aclData.withUnsafeBytes { (p: UnsafeRawBufferPointer) in
+            guard let baseAddress = p.baseAddress else { return }
+            let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+            pos = channelLabelSet(ptr)
+        }
+        return pos
+    }
+    
+    /* ============================================ */
     // MARK: - public Converter
     /* ============================================ */
     
@@ -20,12 +36,7 @@ extension LayoutConverter {
     /// - Parameter aclData: AudioChannelLayoutData
     /// - Returns: AudioChannelLayoutData
     public func convertAsAACTag(from aclData: AudioChannelLayoutData) -> AudioChannelLayoutData? {
-        var pos: Set<AudioChannelLabel>!
-        aclData.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-            pos = channelLabelSet(ptr)
-        }
+        guard let pos = extractChannelLabelSet(from: aclData) else { return nil }
         var tag: AudioChannelLayoutTag = channelLayoutTagAACForChannelLabelSet(pos, true)
         if (tag & 0xFFFF0000) == kAudioChannelLayoutTag_Unknown {
             let tag1 = channelLayoutTagAACForChannelLabelSet(pos, false)
@@ -44,12 +55,7 @@ extension LayoutConverter {
     /// - Parameter aclData: AudioChannelLayoutData
     /// - Returns: AudioChannelLayoutData
     public func convertAsPCMTag(from aclData: AudioChannelLayoutData) -> AudioChannelLayoutData? {
-        var pos: Set<AudioChannelLabel>!
-        aclData.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-            pos = channelLabelSet(ptr)
-        }
+        guard let pos = extractChannelLabelSet(from: aclData) else { return nil }
         let tag: AudioChannelLayoutTag = channelLayoutTagLPCMForChannelLabelSet(pos)
         if (tag & 0xFFFF0000) != kAudioChannelLayoutTag_Unknown {
             let data = dataFor(tag: tag)
@@ -64,12 +70,7 @@ extension LayoutConverter {
     /// - Parameter aclData: AudioChannelLayoutData
     /// - Returns: AudioChannelLayoutData
     public func convertAsBitmap(from aclData: AudioChannelLayoutData) -> AudioChannelLayoutData? {
-        var pos: Set<AudioChannelLabel>!
-        aclData.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-            pos = channelLabelSet(ptr)
-        }
+        guard let pos = extractChannelLabelSet(from: aclData) else { return nil }
         let bitmap: AudioChannelBitmap = channelBitmapForChannelLabelSet(pos)
         if bitmap != [] {
             let data = dataFor(bitmap: bitmap)
@@ -84,12 +85,7 @@ extension LayoutConverter {
     /// - Parameter aclData: AudioChannelLayoutData
     /// - Returns: AudioChannelLayoutData
     public func convertAsDescriptions(from aclData: AudioChannelLayoutData) -> AudioChannelLayoutData? {
-        var pos: Set<AudioChannelLabel>!
-        aclData.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-            pos = channelLabelSet(ptr)
-        }
+        guard let pos = extractChannelLabelSet(from: aclData) else { return nil }
         let descs: [AudioChannelDescription] = channelDescriptionsForChannelLabelSet(pos)
         if descs.count > 0 {
             let data = dataFor(descriptions: descs)

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -21,22 +21,36 @@ extension LayoutConverter {
         var pos: Set<AudioChannelLabel>?
         aclData.withUnsafeBytes { (p: UnsafeRawBufferPointer) in
             guard let baseAddress = p.baseAddress else { return }
-            // Defensive: ensure the buffer holds at least the AudioChannelLayout
-            // header (12 bytes) before reading tag / bitmap / description count.
-            guard p.count >= MemoryLayout<AudioChannelLayout>.size else { return }
-            let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+            // The AudioChannelLayout header occupies the first 12 bytes:
+            //   mChannelLayoutTag (UInt32) + mChannelBitmap (UInt32) + mNumberChannelDescriptions (UInt32).
+            // Note: MemoryLayout<AudioChannelLayout>.size is 32 on real platforms
+            // (the struct includes a trailing mChannelDescriptions[1] for variable-length
+            // array trick), so we use 3 * MemoryLayout<UInt32>.size to express the
+            // header-only bound instead. This lets tag/bitmap layouts (12 bytes) through
+            // while still rejecting undersized buffers. Matches L-04's commented-out
+            // precondition in LayoutConverter+LayoutData.swift:23.
+            let headerSize = 3 * MemoryLayout<UInt32>.size
+            guard p.count >= headerSize else { return }
+            // Peek at the tag without binding AudioChannelLayout (which would require
+            // the full struct size, 32 bytes). Treat the first 12 bytes as three UInt32s.
+            let tagPtr = baseAddress.assumingMemoryBound(to: AudioChannelLayoutTag.self)
+            let tag = tagPtr.pointee
             // For kAudioChannelLayoutTag_UseChannelDescriptions, channelLabelSet reads
-            // `mNumberChannelDescriptions` AudioChannelDescription values (8 bytes each)
-            // past the header. Verify the buffer holds the full size before calling,
-            // matching the L-04 intent of the commented-out precondition
-            // LayoutConverter+LayoutData.swift:23 (precondition(size >= acLayoutSize)).
-            let header = ptr.pointee
-            if header.mChannelLayoutTag == kAudioChannelLayoutTag_UseChannelDescriptions {
-                let descCount = Int(header.mNumberChannelDescriptions)
-                let requiredSize = MemoryLayout<AudioChannelLayout>.size
+            // mNumberChannelDescriptions AudioChannelDescription values (20 bytes each
+            // — Float32 label + UInt32 flags + Float32[3] coordinates) past the header.
+            // Verify the buffer holds the full size before calling.
+            if tag == kAudioChannelLayoutTag_UseChannelDescriptions {
+                let descCountPtr = baseAddress
+                    .advanced(by: 2 * MemoryLayout<UInt32>.size)
+                    .assumingMemoryBound(to: UInt32.self)
+                let descCount = Int(descCountPtr.pointee)
+                let requiredSize = headerSize
                     + max(0, descCount - 1) * MemoryLayout<AudioChannelDescription>.size
                 guard p.count >= requiredSize else { return }
             }
+            // Now safe to bind for channelLabelSet (the UseChannelDescriptions
+            // branch has already verified sufficient capacity above).
+            let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
             pos = channelLabelSet(ptr)
         }
         return pos

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -21,11 +21,22 @@ extension LayoutConverter {
         var pos: Set<AudioChannelLabel>?
         aclData.withUnsafeBytes { (p: UnsafeRawBufferPointer) in
             guard let baseAddress = p.baseAddress else { return }
-            // Defensive: ensure the buffer is at least one AudioChannelLayout
-            // (matches the L-04 intent of the commented-out precondition
-            // in LayoutConverter+LayoutData.swift:23).
+            // Defensive: ensure the buffer holds at least the AudioChannelLayout
+            // header (12 bytes) before reading tag / bitmap / description count.
             guard p.count >= MemoryLayout<AudioChannelLayout>.size else { return }
             let ptr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+            // For kAudioChannelLayoutTag_UseChannelDescriptions, channelLabelSet reads
+            // `mNumberChannelDescriptions` AudioChannelDescription values (8 bytes each)
+            // past the header. Verify the buffer holds the full size before calling,
+            // matching the L-04 intent of the commented-out precondition
+            // LayoutConverter+LayoutData.swift:23 (precondition(size >= acLayoutSize)).
+            let header = ptr.pointee
+            if header.mChannelLayoutTag == kAudioChannelLayoutTag_UseChannelDescriptions {
+                let descCount = Int(header.mNumberChannelDescriptions)
+                let requiredSize = MemoryLayout<AudioChannelLayout>.size
+                    + max(0, descCount - 1) * MemoryLayout<AudioChannelDescription>.size
+                guard p.count >= requiredSize else { return }
+            }
             pos = channelLabelSet(ptr)
         }
         return pos

--- a/cutter2/Utilities/LayoutConverter+Convert.swift
+++ b/cutter2/Utilities/LayoutConverter+Convert.swift
@@ -25,7 +25,6 @@ extension LayoutConverter {
             // the helper adapts to struct definition changes (e.g. Apple adding
             // fields, changing padding, or redefining alignment on a future
             // platform).
-            let descArrayOffset = MemoryLayout<AudioChannelLayout>.offset(of: \.mChannelDescriptions) ?? 0
             let descSize = MemoryLayout<AudioChannelDescription>.size
             let structSize = MemoryLayout<AudioChannelLayout>.size
             // bindMemory with capacity 1 requires structSize contiguous bytes
@@ -36,11 +35,11 @@ extension LayoutConverter {
             let tag = headerPtr.pointee.mChannelLayoutTag
             let descCount = Int(headerPtr.pointee.mNumberChannelDescriptions)
             // For UseChannelDescriptions, channelLabelSet walks descCount
-            // AudioChannelDescription values starting at descArrayOffset. The
-            // first slot is already covered by structSize (the trailing
-            // mChannelDescriptions[1] inside AudioChannelLayout), so we only
-            // need to add (descCount - 1) more. For other tags, channelLabelSet
-            // only touches the header fields and structSize is sufficient.
+            // AudioChannelDescription values past the header. The first slot is
+            // already covered by structSize (the trailing mChannelDescriptions[1]
+            // inside AudioChannelLayout), so we only need to add (descCount - 1)
+            // more. For other tags, channelLabelSet only touches the header fields
+            // and structSize is sufficient.
             let requiredSize: Int
             if tag == kAudioChannelLayoutTag_UseChannelDescriptions {
                 // A UseChannelDescriptions tag with descCount == 0 is malformed

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -95,7 +95,7 @@ class CAPARViewController: NSViewController {
         
         let textHandler: @Sendable (Notification) -> Void = { [weak self] notification in
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard
                 let sheetWindow = performSyncOnMainActor({ self.view.window }),
                 let control = notification.object as? NSControl,

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -58,7 +58,7 @@ extension ViewController {
     internal func addWindowResizeObserver() {
         let handler: @Sendable (Notification) -> Void = {[weak self] (notification) in // @escaping
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard
                 let vcWindow = performSyncOnMainActor({ self.view.window }),
                 let object = notification.object as? NSWindow,
@@ -104,7 +104,7 @@ extension ViewController {
     internal func addUpdateReqObserver() {
         let handler: @Sendable (Notification) -> Void = { [weak self] (notification) in // @escaping
             
-            guard let self else { preconditionFailure("Unexpected nil self detected.") }
+            guard let self else { return }
             guard
                 let delegate = performSyncOnMainActor({ self.delegate }),
                 let object = notification.object as? ViewControllerDelegate,


### PR DESCRIPTION
## Summary

Closes `cutter2_backlog.md` items **H-01, H-02, H-03, H-04** (🟠 High tier).

Three independent concurrency/correctness fixes:

- **H-01** — `MovieMutator.cancel()` doc comment reconciled with actor-hop async semantics (`actor MovieWriter` makes the `await` technically required for the actor hop, not for structured concurrency cancellation)
- **H-02 (a)** — 18 weak-capture teardown sites converted from `preconditionFailure` to `return` (notification handlers, sheet completions, seek completions, media data callbacks, async Task closures). `self` becoming `nil` is normal document/view-controller lifecycle, not a programming error.
- **H-02 (b)** — 8 `@MainActor` nil-check sites converted to `throw`/`return`/`NSSound.beep(); return` per existing `Document+UI.swift` house style. `prepareSavePanel` returns `false` to cancel save panel per AppKit contract.
- **H-03** — `LayoutConverter+Convert.swift` IUO pattern (`var pos: Set<AudioChannelLabel>!` × 4) eliminated by extracting a private helper `extractChannelLabelSet(from:)` that returns `Set<AudioChannelLabel>?` (optional). The four `convert*` methods now safely return `nil` on empty/invalid input instead of reading an uninitialized IUO.
- **H-04** — `MovieMutatorBase.progressStream()` reentrancy hazard (`Thread.isMainThread` branch + `DispatchQueue.main.sync`) replaced with non-throwing `ActorUtilities.performSyncOnMainActor` overload.

26 total `preconditionFailure` sites replaced across 12 files. 22 internal-invariant sites preserved as `preconditionFailure` (storyboard wiring, unsafe pointer, movie data corruption).

## Commits

1. `3ca6fdb` — H-01/H-03/H-04 (doc fix, IUO cleanup, reentrancy fix)
2. `8105230` — H-02 (a): 18 weak-capture teardown `return` conversions
3. `fb63886` — H-02 (b): 8 `@MainActor` nil-check `throw`/`return` conversions

## Verification

- Xcode Build / Analyze: SUCCEEDED (all 3 commits)
- 26 teardown-unsafe `preconditionFailure` → graceful recovery; 22 internal invariants preserved
- 0 remaining `guard let self else { preconditionFailure ` patterns in `[weak self]` closures

## Detailed Plans

- H-01 / H-03 / H-04: `/_plans/H-01_H-03_H-04_concurrency_contract_fix_plan.md` (v5)
- H-02: `/_plans/H-02_preconditionFailure_teardown_crash_fix_plan.md` (v2)

## Backlog Reference

Closes items in `cutter2_backlog.md` — see the "✅ Closed / In Progress" section (10 items).

🤖 Generated with [CommandCode](https://commandcode.ai/)


Co-authored-by: CommandCodeBot <noreply@commandcode.ai>
