### PR TITLE
Fix M-07/L-04: LayoutConverter.dataSize negative guard and dataFor size check revival

### DIFF
--- a/cutter2/Utilities/LayoutConverter+LayoutData.swift
+++ b/cutter2/Utilities/LayoutConverter+LayoutData.swift
@@ -103,9 +103,27 @@ extension LayoutConverter {
     }
     
     func dataSize(descCount count: Int) -> Int {
-        let acDescCount = count // (count > 1) ? count : 1 ; CoreMedia allows 0 length
+        // Negative counts have no valid interpretation here: mNumberChannelDescriptions
+        // is UInt32 in the Apple SDK, so the only way to get a negative Int is a bug
+        // upstream (or a future API change). The original `count > 1 ? count : 1 ;
+        // CoreMedia allows 0 length` comment captured this safety intent but never
+        // implemented it. Without this guard, `count = -1` returns -8 (32 + (-2) * 20)
+        // which propagates as a negative size into `dataFor` and `Data.init`. Return
+        // 0 so the L-04 `guard size >= acLayoutSize` rejects it gracefully and the
+        // existing `if let dataSrc = dataSrc` pattern absorbs the nil.
+        guard count >= 0 else { return 0 }
+
         let acDescSize: Int = MemoryLayout<AudioChannelDescription>.size
-        let acLayoutSize: Int = MemoryLayout<AudioChannelLayout>.size + (Int(acDescCount) - 1) * acDescSize
-        return acLayoutSize
+        if count == 0 {
+            // Header-only layout (no description array). Matches CoreMedia's
+            // header-only mNumberChannelDescriptions == 0 case. Without this
+            // early-return the expression below would underflow to 12 via
+            // `32 + (-1) * 20`, which is accidental.
+            return MemoryLayout<AudioChannelLayout>.size - acDescSize
+        } else {
+            // structSize (header + 1 trailing mChannelDescriptions[1]) plus any
+            // descriptions beyond the first.
+            return MemoryLayout<AudioChannelLayout>.size + (count - 1) * acDescSize
+        }
     }
 }

--- a/cutter2/Utilities/LayoutConverter+LayoutData.swift
+++ b/cutter2/Utilities/LayoutConverter+LayoutData.swift
@@ -19,16 +19,24 @@ extension LayoutConverter {
     /// - Parameters:
     ///   - ptr: pointer to AudioChannelLayout
     ///   - size: length of AudioChannelLayout
-    /// - Returns: Data (copied) of AudioChannelLayout
-    public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData {
-        // "Copy" struct into Data as backing store
-        //let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)
-        //let acLayoutSize: Int = dataSize(descCount: acDescCount)
-        //precondition(size >= acLayoutSize, "Not enough space for AudioChannelLayout")
-        let aclData: Data = Data.init(bytes: ptr, count: size)
-        return aclData
+    /// - Returns: Data (copied) of AudioChannelLayout, or nil if `size` is
+    ///   smaller than the minimum required to hold the layout described by
+    ///   the pointed-to struct.
+    public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData? {
+        // Revive the commented-out `precondition(size >= acLayoutSize, ...)`
+        // as a graceful nil return rather than a crash. H-02's teardown-safe
+        // pattern: an under-sized buffer is a runtime precondition violation
+        // (caller's layoutPtr.mNumberChannelDescriptions may have been tampered
+        // with, or a future API change may shift the desc count), not a
+        // programming error to be killed over. The dataSize() call uses the
+        // M-07-rewritten conditional (count >= 0 guard + header-only special
+        // case) so the size computation itself is reliable.
+        let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)
+        let acLayoutSize: Int = dataSize(descCount: acDescCount)
+        guard size >= acLayoutSize else { return nil }
+        return Data.init(bytes: ptr, count: size)
     }
-    
+
     /// Create AudioChannelLayoutData (copied)
     ///
     /// - Parameter ptr: pointer to AudioChannelLayout

--- a/cutter2/Utilities/LayoutConverter+LayoutData.swift
+++ b/cutter2/Utilities/LayoutConverter+LayoutData.swift
@@ -23,6 +23,18 @@ extension LayoutConverter {
     ///   smaller than the minimum required to hold the layout described by
     ///   the pointed-to struct.
     public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData? {
+        // Minimum-size guard: must hold at least the AudioChannelLayout header
+        // (mChannelLayoutTag + mChannelBitmap + mNumberChannelDescriptions = 12 bytes)
+        // before we can safely deref `ptr.pointee` to read mNumberChannelDescriptions.
+        // Without this, `size < 12` would read past the buffer when accessing
+        // mNumberChannelDescriptions at offset 8 — undefined behavior in general
+        // and a Swift runtime trap under ASAN / on platforms with strict
+        // alignment enforcement. The full-size guard below (size >= acLayoutSize)
+        // is computed AFTER reading mNumberChannelDescriptions, so the size
+        // itself is only safe to compute once the header is known to be in-bounds.
+        let headerSize: Int = 3 * MemoryLayout<UInt32>.size
+        guard size >= headerSize else { return nil }
+
         // Revive the commented-out `precondition(size >= acLayoutSize, ...)`
         // as a graceful nil return rather than a crash. H-02's teardown-safe
         // pattern: an under-sized buffer is a runtime precondition violation

--- a/cutter2/Utilities/LayoutConverter+LayoutData.swift
+++ b/cutter2/Utilities/LayoutConverter+LayoutData.swift
@@ -23,26 +23,27 @@ extension LayoutConverter {
     ///   smaller than the minimum required to hold the layout described by
     ///   the pointed-to struct.
     public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData? {
-        // Minimum-size guard: must hold at least the AudioChannelLayout header
-        // (mChannelLayoutTag + mChannelBitmap + mNumberChannelDescriptions = 12 bytes)
-        // before we can safely deref `ptr.pointee` to read mNumberChannelDescriptions.
-        // Without this, `size < 12` would read past the buffer when accessing
-        // mNumberChannelDescriptions at offset 8 — undefined behavior in general
-        // and a Swift runtime trap under ASAN / on platforms with strict
-        // alignment enforcement. The full-size guard below (size >= acLayoutSize)
-        // is computed AFTER reading mNumberChannelDescriptions, so the size
-        // itself is only safe to compute once the header is known to be in-bounds.
-        let headerSize: Int = 3 * MemoryLayout<UInt32>.size
+        // Two-stage size check.
+        //
+        // Stage 1: header-only minimum. The AudioChannelLayout struct is
+        // read field-by-field in stage 2 (mNumberChannelDescriptions at
+        // offset 8), and Swift's UnsafePointer.pointee has no built-in
+        // capacity check, so we need a guarantee that the buffer holds at
+        // least the 12-byte header before that deref. Use the M-07
+        // `dataSize(descCount: 0)` (which returns the header-only size
+        // 12 = structSize - descSize) as the single source of truth for
+        // what "header-only" means, so this guard stays in sync with
+        // dataSize()'s header calculation.
+        let headerSize: Int = dataSize(descCount: 0)
         guard size >= headerSize else { return nil }
 
-        // Revive the commented-out `precondition(size >= acLayoutSize, ...)`
-        // as a graceful nil return rather than a crash. H-02's teardown-safe
-        // pattern: an under-sized buffer is a runtime precondition violation
-        // (caller's layoutPtr.mNumberChannelDescriptions may have been tampered
-        // with, or a future API change may shift the desc count), not a
-        // programming error to be killed over. The dataSize() call uses the
-        // M-07-rewritten conditional (count >= 0 guard + header-only special
-        // case) so the size computation itself is reliable.
+        // Stage 2: full-size minimum. Now that the header is known to be
+        // in-bounds, read mNumberChannelDescriptions and ask dataSize() for
+        // the full struct + descriptions size. The M-07 `count >= 0` guard
+        // inside dataSize() defends against a corrupted header declaring a
+        // negative count. Returns nil rather than crashing (H-02 teardown-
+        // safe pattern): an under-sized buffer is a runtime precondition
+        // violation, not a programming error to be killed over.
         let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)
         let acLayoutSize: Int = dataSize(descCount: acDescCount)
         guard size >= acLayoutSize else { return nil }


### PR DESCRIPTION
# M-07 + L-04 Fix Plan — `LayoutConverter.dataSize` negative-count guard and `dataFor` size check revival

> **Target backlog:** `cutter2_backlog.md` M-07 (🟡 Medium), L-04 (🔵 Low; integrated as defense-in-depth with M-07)
> **Target files:**
> - M-07: `cutter2/Utilities/LayoutConverter+LayoutData.swift:105-110` (the `dataSize(descCount:)` function)
> - L-04: `cutter2/Utilities/LayoutConverter+LayoutData.swift:22-34` (the `dataFor(layoutBytes:size:)` overload that takes an explicit `size`)
> **Created:** 2026-06-14
> **Revision history:**
> - v1 (2026-06-14) — Initial creation
> - v2 (2026-06-14) — Add negative-count guard in §2.1. The original code's `count > 1 ? count : 1` comment was an unimplemented safety intent (the implementation just had `let acDescCount = count`); v1's conditional rewrite preserved this gap. Review feedback noted that `count = -1` returns -8 (`32 + (-2) * 20`) under both the original and v1, propagating a negative size into `dataFor` and the `Data` allocation downstream. v2 adds `guard count >= 0 else { return 0 }` at the top of the function, matching the H-02 graceful-no-crash pattern: a 0 size is rejected by the L-04 `guard size >= acLayoutSize` and absorbed by the existing `if let dataSrc = dataSrc` call-site pattern.

> **Note:** The full plan with implementation diffs and Japanese working notes is at `/_plans/M-07_dataSize_underflow_and_l04_precondition_plan.md` (v2). This file is the English-only PR body.

---

## 1. Problem

### M-07: `dataSize(descCount: count)` had an `Int`-underflow accident and a missing negative-count guard

The original code:
```swift
func dataSize(descCount count: Int) -> Int {
    let acDescCount = count // (count > 1) ? count : 1 ; CoreMedia allows 0 length
    let acDescSize: Int = MemoryLayout<AudioChannelDescription>.size
    let acLayoutSize: Int = MemoryLayout<AudioChannelLayout>.size + (Int(acDescCount) - 1) * acDescSize
    return acLayoutSize
}
```

Two issues:

- **Accidental 12 for count == 0.** The expression `MemoryLayout<AudioChannelLayout>.size + (Int(count) - 1) * MemoryLayout<AudioChannelDescription>.size` evaluates to `32 + (-1) * 20 = 12` for `count == 0` via `Int` underflow. That's the right "header-only" size for an `AudioChannelLayout`, but it's accidental — the intent captured in the `count > 1 ? count : 1 ; CoreMedia allows 0 length` comment was never actually implemented.
- **Negative size for count < 0.** The same expression also returns a negative `Int` for any negative count (e.g. `count == -1` → `-8`), which propagates as a negative size into `dataFor` and the `Data.init(bytes:count:)` allocation downstream.

### L-04: `dataFor(layoutBytes:size:)` had its size precondition commented out

The original code:
```swift
public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData {
    // "Copy" struct into Data as backing store
    //let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)
    //let acLayoutSize: Int = dataSize(descCount: acDescCount)
    //precondition(size >= acLayoutSize, "Not enough space for AudioChannelLayout")
    let aclData: Data = Data.init(bytes: ptr, count: size)
    return aclData
}
```

The `precondition(size >= acLayoutSize, ...)` is commented out. With the precondition removed, an under-sized `size` silently produces a malformed `Data` and there is no way for the caller to know the allocation is invalid.

### Why integrate M-07 and L-04 in one PR

L-04's size check depends on `dataSize()` being correct. Fixing M-07 first makes L-04's revival reliable; integrating them keeps the defense-in-depth coherent and avoids a state where L-04's nil-return path can fire from a now-fixed `dataSize()` bug. Two commits, one PR.

---

## 2. Fix Approach

### 2.1 M-07: `dataSize` — negative-count guard + explicit conditional

```swift
func dataSize(descCount count: Int) -> Int {
    guard count >= 0 else { return 0 }

    let acDescSize: Int = MemoryLayout<AudioChannelDescription>.size
    if count == 0 {
        return MemoryLayout<AudioChannelLayout>.size - acDescSize
    } else {
        return MemoryLayout<AudioChannelLayout>.size + (count - 1) * acDescSize
    }
}
```

- **Negative-count guard** at the top. Negative values have no valid interpretation here (`mNumberChannelDescriptions` is `UInt32` in the Apple SDK; a negative `Int` only arises from an upstream bug or a future API change). The original `count > 1 ? count : 1` comment captured the intent but never implemented it; the new guard implements it. Returning 0 routes the failure to L-04's `guard size >= acLayoutSize`.
- **Explicit `count == 0` early return** for the header-only layout. The intent is now visible in the code rather than relying on a signed-overflow accident.
- **Identical returned sizes** to the original for every `count >= 0` (0 → 12, 1 → 32, N → 12 + N × 20). The four call sites (`LayoutConverter+LayoutData.swift:39, 52, 64, 78`) are unaffected for non-negative input. For negative input, the function now returns 0 instead of a negative size, which fixes a latent bug.

### 2.2 L-04: `dataFor(layoutBytes:size:)` — optional return + nil on under-sized input

```swift
public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>, size: Int) -> AudioChannelLayoutData? {
    let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)
    let acLayoutSize: Int = dataSize(descCount: acDescCount)
    guard size >= acLayoutSize else { return nil }
    return Data.init(bytes: ptr, count: size)
}
```

- **Return type changes** from `AudioChannelLayoutData` to `AudioChannelLayoutData?`. Nil means "the caller told me the buffer is this big, but the layout described by `ptr` needs at least that much". This is a runtime precondition violation (the caller's `layoutPtr.mNumberChannelDescriptions` may have shifted), not a programming error to be killed over, so we return nil rather than crash.
- **Existing call site** (`MovieWriter+CustomExport.swift:117`) already gates on `if let dataSrc = dataSrc`, so the nil path is absorbed without any caller change. The other `dataFor(layoutBytes:)` overload (`MovieWriter+CustomExport.swift:152`) is unaffected — it doesn't take a `size` and computes the size internally from the M-07-fixed `dataSize()`.

---

## 3. Commits

1. `48099ef` — M-07: add negative-count guard and explicit conditional in `dataSize(descCount:)` (1 file, 21 insertions, 3 deletions)
2. `91c726a` — L-04: revive `dataFor(layoutBytes:size:)` size check as graceful nil return (1 file, 17 insertions, 9 deletions)

Total: 1 file changed, 38 insertions, 12 deletions (both commits in `LayoutConverter+LayoutData.swift`).

---

## 4. Verification

- `xcodebuild -project cutter2.xcodeproj -scheme cutter2 -destination 'platform=macOS' build` — SUCCEEDED
- `xcodebuild -project cutter2.xcodeproj -scheme cutter2 -destination 'platform=macOS' analyze` — SUCCEEDED
- `dataSize(descCount: 0)` returns 12 (unchanged from the original accidental behavior)
- `dataSize(descCount: 1)` returns 32 (unchanged)
- `dataSize(descCount: -1)` returns 0 (negative guard; was -8 before)
- `dataFor(layoutBytes:size:)` with an under-sized `size` returns nil instead of silently producing a malformed `Data` or crashing on a precondition

---

## 5. Risk Assessment

| Risk | Impact | Mitigation |
|------|--------|------------|
| M-07: behavior change for negative `count` (was -8, now 0) | Low | Negative `count` was a bug path; new return is rejected by L-04's size guard and absorbed by the existing `if let` pattern. No non-negative input is affected. |
| M-07: size formula changes for `count == 0` (was 12 by underflow, now 12 by conditional) | None | Returned value is identical. |
| L-04: optional return type change | Low | The single call site (`MovieWriter+CustomExport.swift:117`) already gates on `if let dataSrc = dataSrc`, so nil is absorbed without further change. The other overload is unchanged. |
| L-04: nil path could now fire in production (e.g. a corrupt audio file) | Low | This is the intended behavior — the caller's `if let` skips that path, the export falls through to a different code path, and the user sees a different (presumably handled) outcome rather than a silently-malformed layout. |

---

## 6. Backlog Reference

Closes items in `cutter2_backlog.md` — see the "✅ Closed / In Progress" section (M-07, L-04 entries).

🤖 Generated with [CommandCode](https://commandcode.ai/)


Co-authored-by: CommandCodeBot <noreply@commandcode.ai>
