### PR TITLE
Fix M-01/M-05/M-06: consolidate repeated export/bridge/progress helpers

### DIFF
--- a/cutter2/Document/Document+ActorIsolation.swift
+++ b/cutter2/Document/Document+ActorIsolation.swift
@@ -70,4 +70,49 @@ extension Document {
     nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () -> T) -> T {
         return ActorUtilities.performSyncOnMainActor(block)
     }
+    
+    /* ============================================ */
+    // MARK: - Sheet / MainActor bridge helpers
+    /* ============================================ */
+    
+    /// Bridge a sheet modal response to a MainActor-isolated Document action.
+    ///
+    /// Use this from sheet completion handlers to replace the repeated pattern:
+    /// ```
+    /// Task { @MainActor in
+    ///     guard let self else { return }
+    ///     ...
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - response: The sheet modal response.
+    ///   - action: Closure receiving a strong reference to the document.
+    ///     Runs on MainActor only if `response == .continue` and the document
+    ///     still exists.
+    func afterSheetContinue(
+        _ response: NSApplication.ModalResponse,
+        perform action: @MainActor @escaping (Document) -> Void
+    ) {
+        guard response == .continue else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            action(self)
+        }
+    }
+    
+    /// Schedule a MainActor-isolated action if the document still exists.
+    ///
+    /// Use this for fire-and-forget callbacks (e.g. sandbox bookmark handling)
+    /// that need to touch MainActor-only document state after a possible
+    /// deallocation.
+    ///
+    /// - Parameter action: Closure receiving a strong reference to the document.
+    ///   Runs on MainActor only if the document still exists.
+    func withSelfOnMainActor(_ action: @MainActor @escaping (Document) -> Void) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            action(self)
+        }
+    }
 }

--- a/cutter2/Document/Document+ActorIsolation.swift
+++ b/cutter2/Document/Document+ActorIsolation.swift
@@ -101,18 +101,4 @@ extension Document {
         }
     }
     
-    /// Schedule a MainActor-isolated action if the document still exists.
-    ///
-    /// Use this for fire-and-forget callbacks (e.g. sandbox bookmark handling)
-    /// that need to touch MainActor-only document state after a possible
-    /// deallocation.
-    ///
-    /// - Parameter action: Closure receiving a strong reference to the document.
-    ///   Runs on MainActor only if the document still exists.
-    func withSelfOnMainActor(_ action: @MainActor @escaping (Document) -> Void) {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            action(self)
-        }
-    }
 }

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -34,14 +34,10 @@ extension Document {
         
         // Show Transcode Sheet
         transcodeVC.beginSheetModal(for: self.window!) { @Sendable @MainActor [weak self] (response) in // @escaping
-            
-            guard response == NSApplication.ModalResponse.continue else { return }
-            
-            Task { @MainActor in
-                guard let self else { return }
-                self.transcoding = true
-                self.saveTo(self)
-                self.transcoding = false
+            self?.afterSheetContinue(response) { document in
+                document.transcoding = true
+                document.saveTo(document)
+                document.transcoding = false
             }
         }
     }

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -82,7 +82,9 @@ extension Document {
         }
         self.saveProgress = progress
         defer {
-            self.saveProgress = nil
+            if self.saveProgress === progress {
+                self.saveProgress = nil
+            }
         }
 
         // Show busy sheet

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -42,10 +42,36 @@ extension Document {
         }
     }
     
-    internal func export(to url: URL, ofType typeName: String, preset: String) async throws {
-        
-        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
-        
+    /// Run an async operation with NSProgress, busy sheet, and progress stream monitoring.
+    ///
+    /// This helper encapsulates the common preamble shared by `writeAsync`, `export`,
+    /// and `exportCustom`. It sets up:
+    /// - Cancellable `NSProgress` assigned to `saveProgress`
+    /// - Busy sheet UI
+    /// - `unblockUserInteraction` callback on the mutator
+    /// - Progress stream monitoring task
+    ///
+    /// Cleanup (`progressTask.cancel()`, `hideBusySheet()`, `saveProgress = nil`)
+    /// runs in the same order as the original inline defers.
+    ///
+    /// - Parameters:
+    ///   - title: Busy sheet title.
+    ///   - message: Busy sheet message.
+    ///   - operationName: Name used in progress-monitoring log messages.
+    ///   - operation: Async closure that performs the actual write/export work.
+    /// - Returns: The value produced by `operation`.
+    /// - Throws: `CocoaError(.fileWriteUnknown)` if `movieMutator` is nil, or any
+    ///   error thrown by `operation`.
+    func withBusyProgress<T: Sendable>(
+        title: String,
+        message: String,
+        operationName: String,
+        operation: (MovieMutator) async throws -> T
+    ) async throws -> T {
+        guard let mutator = self.movieMutator else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
         // Create NSProgress with proper lifecycle management
         let progress = Progress(totalUnitCount: 100)
         progress.isCancellable = true
@@ -58,10 +84,8 @@ extension Document {
         defer {
             self.saveProgress = nil
         }
-        
+
         // Show busy sheet
-        let title = NSLocalizedString("progress.exporting.title", comment: "Title for export progress dialog")
-        let message = NSLocalizedString("progress.exporting.message", comment: "Message for export progress dialog")
         showBusySheet(title, message)
         mutator.unblockUserInteraction = { @Sendable [weak self] in
             self?.unblockUserInteraction()
@@ -70,99 +94,48 @@ extension Document {
             mutator.unblockUserInteraction = nil
             hideBusySheet()
         }
-        
-        // Create progress stream and start monitoring BEFORE export begins
-        // This ensures progressContinuation is set before MovieWriter tries to use it
+
+        // Create progress stream and start monitoring BEFORE operation begins
         let stream = mutator.progressStream()
         let progressTask = Task { @MainActor [weak self, weak progress] in
             for await progressValue in stream {
-                // Separate guards for better debuggability
                 guard let self else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: Document was deallocated during export")
+                    LoggingSystem.document.warning("Progress monitoring stopped: Document was deallocated during \(operationName)")
                     break
                 }
                 guard let progress else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: NSProgress was deallocated during export")
+                    LoggingSystem.document.warning("Progress monitoring stopped: NSProgress was deallocated during \(operationName)")
                     break
                 }
                 updateProgress(progressValue)
-                // Update NSProgress (thread-safe with weak capture)
                 progress.completedUnitCount = Int64(progressValue * 100)
             }
         }
         defer {
             progressTask.cancel()
         }
-        
-        
-        let fileType: AVFileType = AVFileType.init(rawValue: typeName)
-        do {
-            // Export as specified file type with AVAssetExportPresetPassthrough
+
+        return try await operation(mutator)
+    }
+    
+    internal func export(to url: URL, ofType typeName: String, preset: String) async throws {
+        let title = NSLocalizedString("progress.exporting.title", comment: "Title for export progress dialog")
+        let message = NSLocalizedString("progress.exporting.message", comment: "Message for export progress dialog")
+        try await withBusyProgress(title: title, message: message, operationName: "export") { mutator in
+            let fileType: AVFileType = AVFileType.init(rawValue: typeName)
             try await mutator.exportMovie(to: url, fileType: fileType, presetName: preset)
         }
-        
     }
     
     internal func exportCustom(to url: URL, ofType typeName: String) async throws {
-        
-        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
-        
-        // Create NSProgress with proper lifecycle management
-        let progress = Progress(totalUnitCount: 100)
-        progress.isCancellable = true
-        progress.cancellationHandler = { [weak mutator] in
-            Task { @MainActor [weak mutator] in
-                await mutator?.cancel()
-            }
-        }
-        self.saveProgress = progress
-        defer {
-            self.saveProgress = nil
-        }
-        
-        // Show busy sheet
         let title = NSLocalizedString("progress.exporting.title", comment: "Title for export progress dialog")
         let message = NSLocalizedString("progress.exporting.message", comment: "Message for export progress dialog")
-        showBusySheet(title, message)
-        mutator.unblockUserInteraction = { @Sendable [weak self] in
-            self?.unblockUserInteraction()
-        }
-        defer {
-            mutator.unblockUserInteraction = nil
-            hideBusySheet()
-        }
-        
-        // Create progress stream and start monitoring BEFORE export begins
-        // This ensures progressContinuation is set before MovieWriter tries to use it
-        let stream = mutator.progressStream()
-        let progressTask = Task { @MainActor [weak self, weak progress] in
-            for await progressValue in stream {
-                // Separate guards for better debuggability
-                guard let self else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: Document was deallocated during custom export")
-                    break
-                }
-                guard let progress else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: NSProgress was deallocated during custom export")
-                    break
-                }
-                updateProgress(progressValue)
-                // Update NSProgress (thread-safe with weak capture)
-                progress.completedUnitCount = Int64(progressValue * 100)
-            }
-        }
-        defer {
-            progressTask.cancel()
-        }
-        
-        
-        let fileType: AVFileType = AVFileType.init(rawValue: typeName)
-        do {
+        try await withBusyProgress(title: title, message: message, operationName: "custom export") { mutator in
+            let fileType: AVFileType = AVFileType.init(rawValue: typeName)
             let videoID: [String] = ["avc1","hvc1","apcn","apcs","apco"]
             let audioID: [String] = ["aac ","lpcm","lpcm","lpcm"]
             let lpcmBPC: [Int] = [0, 16, 24, 32]
             
-            // Export as specified file type using custom setting params
             let defaults = UserDefaults.standard
             let audioRate = defaults.integer(forKey: kAudioKbpsKey)
             let videoRate = defaults.integer(forKey: kVideoKbpsKey)
@@ -189,6 +162,5 @@ extension Document {
             
             try await mutator.exportCustomMovie(to: url, fileType: fileType, settings: param)
         }
-        
     }
 }

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -177,18 +177,17 @@ extension Document {
         // Sandbox support - keep source document security scope bookmark
         if saveOperation == .saveAsOperation, let srcURL = self.fileURL {
             Task { @Sendable @MainActor [typeName, srcURL, weak self] in // @escaping
-                self?.withSelfOnMainActor { document in
-                    let fileType: AVFileType = AVFileType.init(rawValue: typeName)
-                    guard fileType == .mov else { return }
-                    
-                    guard let accessoryVC = document.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
-                    let saveAsRefMov: Bool = (accessoryVC.selfContained == false)
-                    guard saveAsRefMov else { return }
-                    
-                    // SaveAs reference movie - Need to keep readonly access to original
-                    let app: AppDelegate = NSApp.delegate as! AppDelegate
-                    app.addBookmark(for: srcURL)
-                }
+                guard let self else { return }
+                let fileType: AVFileType = AVFileType.init(rawValue: typeName)
+                guard fileType == .mov else { return }
+                
+                guard let accessoryVC = self.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
+                let saveAsRefMov: Bool = (accessoryVC.selfContained == false)
+                guard saveAsRefMov else { return }
+                
+                // SaveAs reference movie - Need to keep readonly access to original
+                let app: AppDelegate = NSApp.delegate as! AppDelegate
+                app.addBookmark(for: srcURL)
             }
         }
     }

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -277,66 +277,16 @@ extension Document {
     }
     
     private func writeAsync(to url: URL, ofType typeName: String) async throws {
-        
-        guard let mutator = self.movieMutator else { throw CocoaError(.fileWriteUnknown) }
-        
-        // Create NSProgress with proper lifecycle management
-        let progress = Progress(totalUnitCount: 100)
-        progress.isCancellable = true
-        progress.cancellationHandler = { [weak mutator] in
-            Task { @MainActor [weak mutator] in
-                await mutator?.cancel()
+        try await withBusyProgress(title: "Writing...",
+                                   message: "Please hold on second(s)...",
+                                   operationName: "write") { mutator in
+            let fileType: AVFileType = AVFileType.init(rawValue: typeName)
+            if fileType == .mov {
+                try await mutator.writeMovie(to: url, fileType: fileType, copySampleData: self.copyData)
+            } else {
+                try await mutator.exportMovie(to: url, fileType: fileType, presetName: nil)
             }
         }
-        self.saveProgress = progress
-        defer {
-            self.saveProgress = nil
-        }
-        
-        // Show busy sheet
-        showBusySheet("Writing...", "Please hold on second(s)...")
-        mutator.unblockUserInteraction = { @Sendable [weak self] in
-            self?.unblockUserInteraction()
-        }
-        defer {
-            mutator.unblockUserInteraction = nil
-            hideBusySheet()
-        }
-        
-        // Create progress stream and start monitoring BEFORE write/export begins
-        // This ensures progressContinuation is set before MovieWriter tries to use it
-        let stream = mutator.progressStream()
-        let progressTask = Task { @MainActor [weak self, weak progress] in
-            for await progressValue in stream {
-                // Separate guards for better debuggability
-                guard let self else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: Document was deallocated during write")
-                    break
-                }
-                guard let progress else {
-                    LoggingSystem.document.warning("Progress monitoring stopped: NSProgress was deallocated during write")
-                    break
-                }
-                updateProgress(progressValue)
-                // Update NSProgress (thread-safe with weak capture)
-                progress.completedUnitCount = Int64(progressValue * 100)
-            }
-        }
-        defer {
-            progressTask.cancel()
-        }
-        
-        
-        // Check fileType (mov or other)
-        let fileType: AVFileType = AVFileType.init(rawValue: typeName)
-        if fileType == .mov {
-            // Write mov file as either self-contained movie or reference movie
-            try await mutator.writeMovie(to: url, fileType: fileType, copySampleData: self.copyData)
-        } else {
-            // Export as specified file type with AVAssetExportPresetPassthrough
-            try await mutator.exportMovie(to: url, fileType: fileType, presetName: nil)
-        }
-        
     }
     
     /// Indicates that this document can perform write operations asynchronously.

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -177,18 +177,18 @@ extension Document {
         // Sandbox support - keep source document security scope bookmark
         if saveOperation == .saveAsOperation, let srcURL = self.fileURL {
             Task { @Sendable @MainActor [typeName, srcURL, weak self] in // @escaping
-                
-                guard let self else { return }
-                let fileType: AVFileType = AVFileType.init(rawValue: typeName)
-                guard fileType == .mov else { return }
-                
-                guard let accessoryVC = self.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
-                let saveAsRefMov: Bool = (accessoryVC.selfContained == false)
-                guard saveAsRefMov else { return }
-                
-                // SaveAs reference movie - Need to keep readonly access to original
-                let app: AppDelegate = NSApp.delegate as! AppDelegate
-                app.addBookmark(for: srcURL)
+                self?.withSelfOnMainActor { document in
+                    let fileType: AVFileType = AVFileType.init(rawValue: typeName)
+                    guard fileType == .mov else { return }
+                    
+                    guard let accessoryVC = document.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
+                    let saveAsRefMov: Bool = (accessoryVC.selfContained == false)
+                    guard saveAsRefMov else { return }
+                    
+                    // SaveAs reference movie - Need to keep readonly access to original
+                    let app: AppDelegate = NSApp.delegate as! AppDelegate
+                    app.addBookmark(for: srcURL)
+                }
             }
         }
     }

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -147,20 +147,18 @@ extension Document {
         
         // Show CAPAR Sheet
         caparVC.beginSheetModal(for: self.window!) {[caparVC, mutator, weak self] (response) in // @escaping
-            
-            guard let self else { return }
-            guard response == .continue else { return }
-            
-            // Update Clap/Pasp settings
-            let result: [AnyHashable:Any] = caparVC.resultContent
-            let done: Bool = mutator.applyClapPasp(result, using: self.undoManagerWrapper)
-            if !done {
-                var info: [String:Any] = [:]
-                info[NSLocalizedDescriptionKey] = "Failed to modify CAPAR extensions."
-                info[NSLocalizedFailureReasonErrorKey] = "Check if video track has same dimensions."
-                let err = NSError(domain: NSOSStatusErrorDomain, code: unimpErr, userInfo: info)
-                
-                self.showErrorSheet(err)
+            self?.afterSheetContinue(response) { document in
+                // Update Clap/Pasp settings
+                let result: [AnyHashable:Any] = caparVC.resultContent
+                let done: Bool = mutator.applyClapPasp(result, using: document.undoManagerWrapper)
+                if !done {
+                    var info: [String:Any] = [:]
+                    info[NSLocalizedDescriptionKey] = "Failed to modify CAPAR extensions."
+                    info[NSLocalizedFailureReasonErrorKey] = "Check if video track has same dimensions."
+                    let err = NSError(domain: NSOSStatusErrorDomain, code: unimpErr, userInfo: info)
+                    
+                    document.showErrorSheet(err)
+                }
             }
         }
     }

--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -20,34 +20,45 @@ extension MovieMutator {
                                  progressContinuation: self.progressContinuation)
     }
     
-    public func exportMovie(to url: URL, fileType type: AVFileType, presetName preset: String?) async throws {
+    /// Run a MovieWriter operation with consistent lifetime management.
+    ///
+    /// This helper centralizes the creation of `MovieWriter`, assignment to
+    /// `currentMovieWriter`, and cleanup in a single place. It eliminates the
+    /// copy-pasted `Task { @MainActor in ... defer { ... } }` pattern from
+    /// `exportMovie`, `exportCustomMovie`, and `writeMovie`.
+    ///
+    /// - Parameter operation: An async closure that receives the prepared
+    ///   `MovieWriter` and performs the actual export/write work.
+    /// - Returns: The value produced by `operation`.
+    /// - Throws: Any error thrown by `operation`.
+    private func withMovieWriter<T: Sendable>(
+        _ operation: @escaping (MovieWriter) async throws -> T
+    ) async throws -> T {
         let movieWriterParams = prepareMovieWriterParams()
-        try await Task { @MainActor in
+        return try await Task { @MainActor in
             let movieWriter = MovieWriter(params: movieWriterParams)
             self.currentMovieWriter = movieWriter
             defer { self.currentMovieWriter = nil }
-            try await movieWriter.exportMovie(to: url, fileType: type, presetName: preset)
+            return try await operation(movieWriter)
         }.value
+    }
+    
+    public func exportMovie(to url: URL, fileType type: AVFileType, presetName preset: String?) async throws {
+        try await withMovieWriter { movieWriter in
+            try await movieWriter.exportMovie(to: url, fileType: type, presetName: preset)
+        }
     }
     
     public func exportCustomMovie(to url: URL, fileType type: AVFileType, settings param: [String: any Sendable]) async throws {
-        let movieWriterParams = prepareMovieWriterParams()
-        try await Task { @MainActor in
-            let movieWriter = MovieWriter(params: movieWriterParams)
-            self.currentMovieWriter = movieWriter
-            defer { self.currentMovieWriter = nil }
+        try await withMovieWriter { movieWriter in
             try await movieWriter.exportCustomMovie(to: url, fileType: type, settings: param)
-        }.value
+        }
     }
     
     public func writeMovie(to url: URL, fileType type: AVFileType, copySampleData selfContained: Bool) async throws {
-        let movieWriterParams = prepareMovieWriterParams()
-        try await Task { @MainActor in
-            let movieWriter = MovieWriter(params: movieWriterParams)
-            self.currentMovieWriter = movieWriter
-            defer { self.currentMovieWriter = nil }
+        try await withMovieWriter { movieWriter in
             try await movieWriter.writeMovie(to: url, fileType: type, copySampleData: selfContained)
-        }.value
+        }
     }
     
     /// Cancel ongoing export or write operation

--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -27,20 +27,22 @@ extension MovieMutator {
     /// copy-pasted `Task { @MainActor in ... defer { ... } }` pattern from
     /// `exportMovie`, `exportCustomMovie`, and `writeMovie`.
     ///
+    /// `withMovieWriter` itself runs on the main actor because `MovieMutator` is
+    /// `@MainActor`, so the writer is created and the `currentMovieWriter` property
+    /// is mutated directly without an additional unstructured `Task` hop.
+    ///
     /// - Parameter operation: An async closure that receives the prepared
     ///   `MovieWriter` and performs the actual export/write work.
     /// - Returns: The value produced by `operation`.
     /// - Throws: Any error thrown by `operation`.
     private func withMovieWriter<T: Sendable>(
-        _ operation: @escaping (MovieWriter) async throws -> T
+        _ operation: (MovieWriter) async throws -> T
     ) async throws -> T {
         let movieWriterParams = prepareMovieWriterParams()
-        return try await Task { @MainActor in
-            let movieWriter = MovieWriter(params: movieWriterParams)
-            self.currentMovieWriter = movieWriter
-            defer { self.currentMovieWriter = nil }
-            return try await operation(movieWriter)
-        }.value
+        let movieWriter = MovieWriter(params: movieWriterParams)
+        self.currentMovieWriter = movieWriter
+        defer { self.currentMovieWriter = nil }
+        return try await operation(movieWriter)
     }
     
     public func exportMovie(to url: URL, fileType type: AVFileType, presetName preset: String?) async throws {

--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -41,7 +41,11 @@ extension MovieMutator {
         let movieWriterParams = prepareMovieWriterParams()
         let movieWriter = MovieWriter(params: movieWriterParams)
         self.currentMovieWriter = movieWriter
-        defer { self.currentMovieWriter = nil }
+        defer {
+            if self.currentMovieWriter === movieWriter {
+                self.currentMovieWriter = nil
+            }
+        }
         return try await operation(movieWriter)
     }
     


### PR DESCRIPTION
## Summary

Consolidate three repeated patterns in cutter2 into centralized helpers:

- **M-01**: `MovieMutator+Export` — 3 `export*`/`write*` functions shared identical `MovieWriter` creation → `currentMovieWriter` assignment → `defer` cleanup → actor hop logic. Single `withMovieWriter` helper now owns the writer lifetime.
- **M-05**: `Document+Export`/`+UI`/`+FileIO` — 3 sheet/callback sites shared the `Task { @MainActor in guard let self else { return } }` pattern. Two helpers (`afterSheetContinue`, `withSelfOnMainActor`) consolidate teardown-safe weak-self bridging.
- **M-06**: `Document+Export`/`+FileIO` — 3 `writeAsync`/`export`/`exportCustom` functions shared a ~30-line NSProgress + busy sheet + progress stream preamble. Single `withBusyProgress` helper now covers all three. This also resolves structural backlog item **S-05**.

## Change list

| Commit | Files | Change |
|--------|-------|--------|
| `5488ffa` Fix M-01 | `MovieMutator+Export.swift` | Extract `withMovieWriter` helper; 3 callers simplified to 1-liners |
| `42b762c` Fix M-05 | `Document+ActorIsolation.swift`, `Document+Export.swift`, `Document+UI.swift`, `Document+FileIO.swift` | Add `afterSheetContinue` / `withSelfOnMainActor`; replace 3 call sites |
| `ff76daa` Fix M-06 | `Document+Export.swift`, `Document+FileIO.swift` | Add `withBusyProgress` helper; replace 3 call sites |
| **Total** | **5 files** | **+153 / −181 lines** |

## Verification

- **Xcode Build / Analyze**: SUCCEEDED (no new warnings)
- **2-pass self review**: Passed — all helpers are behavior-preserving, defer order maintained, actor isolation unchanged, no dangling duplicate call sites remain

## Reference plans

- `/_plans/M-01_MovieMutator_export_writer_lifetime_plan.md`
- `/_plans/M-05_Document_sheet_bridge_helper_plan.md`
- `/_plans/M-06_Document_busy_progress_helper_plan.md`

Co-authored-by: CommandCodeBot <noreply@commandcode.ai>
