### PR TITLE
Fix M-08/M-09/M-10: idempotent cancel and failable-init guards in custom export

### DIFF
--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -83,9 +83,13 @@ extension MovieMutator {
     /// - On the MovieWriter actor, cancellation is synchronous: it sets the writeCancelled
     ///   flag and cancels the export session
     /// - The ongoing export/write operation checks writeCancelled flag and throws OperationCancelled
+    /// - Once the writer reference is captured, `currentMovieWriter` is cleared so that
+    ///   subsequent calls are no-ops until a new export/write operation starts
     public func cancel() async {
         guard let writer = self.currentMovieWriter else { return }
-        // Capture the writer reference to avoid race condition between check and use
+        // Clear the reference before the actor hop so that any subsequent
+        // cancel() calls become no-ops while this cancellation is in flight.
+        self.currentMovieWriter = nil
         await writer.cancelExport()
         await writer.cancelCustomMovie()
     }

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -57,7 +57,7 @@ extension MovieWriter {
         prepareCopyChannels(movie, ar, aw, .depthData)
     }
     
-    private func prepareAudioChannels(_ movie: AVMutableMovie, _ ar: AVAssetReader, _ aw: AVAssetWriter) {
+    private func prepareAudioChannels(_ movie: AVMutableMovie, _ ar: AVAssetReader, _ aw: AVAssetWriter) throws {
         let numAudioEncode = customParam[kAudioEncodeKey] as? NSNumber
         let audioEncode: Bool = numAudioEncode?.boolValue ?? true
         if audioEncode == false {
@@ -179,9 +179,13 @@ extension MovieWriter {
             if let _ = awInputSetting[AVEncoderBitRateKey] {
                 let inFormat = AVAudioFormat(standardFormatWithSampleRate: Double(sampleRate),
                                              channelLayout: avacSrcLayout)
-                let outFormat = AVAudioFormat(settings: awInputSetting)!
-                let converter = AVAudioConverter(from: inFormat, to: outFormat)!
-                let bitrateArray = converter.applicableEncodeBitRates!.map{($0).intValue}
+                guard let outFormat = AVAudioFormat(settings: awInputSetting),
+                      let converter = AVAudioConverter(from: inFormat, to: outFormat),
+                      let bitrates = converter.applicableEncodeBitRates
+                else {
+                    try throwError(.movieWriterFailed, reason: "Invalid audio format/converter settings")
+                }
+                let bitrateArray = bitrates.map { $0.intValue }
                 if bitrateArray.contains(targetBitRate) == false {
                     // bitrate adjustment
                     var prev = bitrateArray.first!
@@ -223,11 +227,11 @@ extension MovieWriter {
                                                   imageBufferAttributes: nil,
                                                   outputCallback: nil,
                                                   decompressionSessionOut: &decompSession)
-            guard status == noErr else { return false }
-            
-            defer { VTDecompressionSessionInvalidate(decompSession!) }
-            
-            status = VTSessionCopySupportedPropertyDictionary(decompSession!,
+            guard status == noErr, let session = decompSession else { return false }
+
+            defer { VTDecompressionSessionInvalidate(session) }
+
+            status = VTSessionCopySupportedPropertyDictionary(session,
                                                               supportedPropertyDictionaryOut: &dict)
             guard status == noErr else { return false }
         }
@@ -573,7 +577,7 @@ extension MovieWriter {
             aw.shouldOptimizeForNetworkUse = true
             
             // Prepare media channels.
-            prepareAudioChannels(movie, ar, aw)
+            try prepareAudioChannels(movie, ar, aw)
             prepareVideoChannels(movie, ar, aw)
             prepareOtherMediaChannels(movie, ar, aw)
             

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -181,7 +181,8 @@ extension MovieWriter {
                                              channelLayout: avacSrcLayout)
                 guard let outFormat = AVAudioFormat(settings: awInputSetting),
                       let converter = AVAudioConverter(from: inFormat, to: outFormat),
-                      let bitrates = converter.applicableEncodeBitRates
+                      let bitrates = converter.applicableEncodeBitRates,
+                      !bitrates.isEmpty
                 else {
                     try throwError(.movieWriterFailed, reason: "Invalid audio format/converter settings")
                 }


### PR DESCRIPTION
# Fix M-08 / M-09 / M-10: force-unwrap and idempotency guards in custom export

## Summary

Three small, independent hardening fixes in the custom-export path:

- **M-08** — `MovieMutator.cancel()` is made idempotent. After capturing the current writer, `currentMovieWriter` is cleared so that subsequent `cancel()` calls are no-ops until the next export/write starts. The doc comment now documents the idempotency contract.
- **M-09** — `prepareAudioChannels` is made `throws` and the three failable audio points (`AVAudioFormat(settings:)`, `AVAudioConverter(from:to:)`, `applicableEncodeBitRates`) are guarded. Invalid user-controlled audio settings now surface as `MovieWriterError.movieWriterFailed` instead of crashing the process. The single call site in `exportCustomMovie` propagates the error with `try`.
- **M-10** — `hasFieldModeSupport(of:)` now combines the `VTDecompressionSessionCreate` status check and the optional session binding into a single `guard`, eliminating the three dispersed `decompSession!` force unwraps.

## Plan

- `/_plans/M-08_cancel_idempotency_plan.md` (v1)
- `/_plans/M-09_audio_format_converter_force_unwrap_plan.md` (v1, with the in-flight correction that `AVAudioFormat(standardFormatWithSampleRate:channelLayout:)` is non-failable and is therefore not included in the guard)
- `/_plans/M-10_vt_decompression_session_force_unwrap_plan.md` (v1)

## Changes

- `cutter2/Models/MovieMutator+Export.swift`
  - `cancel()`: clear `currentMovieWriter` right after the `guard let writer` so repeat calls become no-ops. Doc comment extended to describe the contract.
- `cutter2/Models/MovieWriter+CustomExport.swift`
  - `prepareAudioChannels` signature: `func ... { ... }` → `func ... throws { ... }`.
  - Bitrate validation block: replaced three force unwraps with a single `guard let` covering `outFormat`, `converter`, and `bitrates`. The `else` branch calls `try throwError(.movieWriterFailed, reason: "Invalid audio format/converter settings")`.
  - `exportCustomMovie` call site: `prepareAudioChannels(...)` → `try prepareAudioChannels(...)`.
  - `hasFieldModeSupport(of:)`: combined the `status` check and the `decompSession` optional binding into `guard status == noErr, let session = decompSession else { return false }`. `defer` and `VTSessionCopySupportedPropertyDictionary` now use `session` instead of `decompSession!`.

## Verification

- `xcodebuild -project cutter2.xcodeproj -scheme cutter2 -destination 'platform=macOS' build`: SUCCEEDED.
- `xcodebuild ... analyze`: not run (build is clean; CI is expected to run the analyze gate).
- Manual review of the diff confirmed:
  - The single `try` site is already inside the existing `do { ... }` block in `exportCustomMovie` and propagates to the existing `MovieWriterError.movieWriterFailed` catch path.
  - `withMovieWriter`'s identity-checked `defer` cleanup is unaffected (it sees the cleared reference or the new writer, depending on timing).
  - `hasFieldModeSupport` returning `false` on the new failure path is the existing graceful-degradation behavior.

## Out of scope

- The remaining `preconditionFailure` calls in `prepareAudioChannels` (missing `kAudioCodecKey`, layout conversion failure) are tracked separately.
- No new tests added in this PR; test coverage is tracked under the `T-*` backlog items.

## Risk

Low. No public API changes, no signature changes other than the new `throws` on `prepareAudioChannels` (which is a `private` helper), and no behavioral change for valid inputs.
