### PR TITLE
Refactor S-01/S-02: UndoManagerWrapper @MainActor handler + remove duplicate wrappers

### DIFF
--- a/cutter2/Document/Document+ActorIsolation.swift
+++ b/cutter2/Document/Document+ActorIsolation.swift
@@ -54,23 +54,6 @@ extension Document {
         }
     }
     
-    /// Runs a throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A closure isolated to the main actor that may throw an error.
-    /// - Returns: The result of the closure's operation.
-    /// - Throws: Any error thrown by the closure.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () throws -> T) throws -> T {
-        return try ActorUtilities.performSyncOnMainActor(block)
-    }
-    
-    /// Runs a non-throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A non-throwing closure isolated to the main actor.
-    /// - Returns: The result of the closure's operation.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () -> T) -> T {
-        return ActorUtilities.performSyncOnMainActor(block)
-    }
-    
     /* ============================================ */
     // MARK: - Sheet / MainActor bridge helpers
     /* ============================================ */

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -201,14 +201,14 @@ extension Document {
         
         do {
             // Prepare to save
-            try performSyncOnMainActor {
+            try ActorUtilities.performSyncOnMainActor {
                 try preparation(to: url, ofType: typeName, for: saveOperation)
             }
             
             // Trigger actual write operation (saveTo, save/saveAs)
             try super.writeSafely(to: url, ofType: typeName, for: saveOperation)
         } catch {
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 showErrorSheet(error)
             }
             throw error // rethrow to abort write operation
@@ -216,7 +216,7 @@ extension Document {
         
         // Refresh internal movie (to sync selfcontained <> referece movie change)
         if saveOperation == .saveAsOperation {
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 refreshMutator()
             }
         }

--- a/cutter2/Document/Document+Observers.swift
+++ b/cutter2/Document/Document+Observers.swift
@@ -67,7 +67,7 @@ extension Document {
         }
         
         let contextAddress = UInt(bitPattern: context) // Cast UnsafeMutableRawPointer to UInt for actor isolation
-        let (objectIsPlayer, keyPathIsAVPlayerStatus, keyPathIsAVPlayerRate) = performSyncOnMainActor {
+        let (objectIsPlayer, keyPathIsAVPlayerStatus, keyPathIsAVPlayerRate) = ActorUtilities.performSyncOnMainActor {
             let contextMatch: Bool = checkKVOContext(contextAddress)
             let objectIsPlayer: Bool = (object === self.player)
             let keyPathIsAVPlayerStatus: Bool = (keyPath == #keyPath(AVPlayer.status))
@@ -81,7 +81,7 @@ extension Document {
             guard let newStatus = change[.newKey] as? NSNumber else { return }
             if newStatus.intValue == AVPlayer.Status.readyToPlay.rawValue {
                 // Seek and refresh View
-                performSyncOnMainActor {
+                ActorUtilities.performSyncOnMainActor {
                     guard let mutator = self.movieMutator else { return }
                     let time = mutator.insertionTime
                     let range = mutator.selectedTimeRange
@@ -99,7 +99,7 @@ extension Document {
             guard let newRate = change[.newKey] as? NSNumber else { return }
             if oldRate.floatValue > 0.0 && newRate.floatValue == 0.0 {
                 // Movie stopped
-                performSyncOnMainActor {
+                ActorUtilities.performSyncOnMainActor {
                     guard let player = self.player else { return }
                     guard let mutator = self.movieMutator else { return }
                     
@@ -139,13 +139,13 @@ extension Document {
             
             guard let self else { return }
             guard
-                let mutator = performSyncOnMainActor({ self.movieMutator }),
+                let mutator = ActorUtilities.performSyncOnMainActor({ self.movieMutator }),
                 let object = notification.object as? MovieMutator,
                 mutator == object
             else { return }
             
             #if DEBUG
-            let displayName = performSyncOnMainActor({ self.displayName ?? "unknown" })
+            let displayName = ActorUtilities.performSyncOnMainActor({ self.displayName ?? "unknown" })
             LoggingSystem.document.debug("Received .movieWasMutated notification: \(displayName)")
             #endif
             
@@ -158,7 +158,7 @@ extension Document {
             
             let time: CMTime = timeValue.timeValue
             let timeRange: CMTimeRange = timeRangeValue.timeRangeValue
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 updateGUI(time, timeRange, true)
             }
         }

--- a/cutter2/Document/Document+SavePanel.swift
+++ b/cutter2/Document/Document+SavePanel.swift
@@ -82,7 +82,7 @@ extension Document {
     
     override nonisolated var fileTypeFromLastRunSavePanel: String? {
         
-        return performSyncOnMainActor {
+        return ActorUtilities.performSyncOnMainActor {
             if let accessoryVC = self.accessoryVC {
                 let type: String = accessoryVC.fileType.rawValue
                 return type

--- a/cutter2/Document/Document+SheetControl.swift
+++ b/cutter2/Document/Document+SheetControl.swift
@@ -121,7 +121,7 @@ extension Document {
                 guard let self else { return }
                 if response == .alertFirstButtonReturn {
                     // User clicked Cancel - the cancellationHandler will call mutator.cancel()
-                    performSyncOnMainActor {
+                    ActorUtilities.performSyncOnMainActor {
                         self.saveProgress?.cancel()
                     }
                 }

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -200,7 +200,7 @@ extension Document {
             guard let self else { return }
             guard let player = player else { return }
             guard let mutator = mutator else { return }
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 updateRate(player, rate)
                 updateTimeline(time, range: mutator.selectedTimeRange)
             }
@@ -250,7 +250,7 @@ extension Document {
                 
                 guard let self else { return }
                 guard let pv = pv else { return }
-                performSyncOnMainActor {
+                ActorUtilities.performSyncOnMainActor {
                     pv.needsDisplay = true
                 }
             }

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -198,8 +198,8 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoCutHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
-            let redoCutHandler: @MainActor (MovieMutator) -> Void = {[range, time] (me2) in // @escaping
+        let undoCutHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
+            let redoCutHandler: @MainActor (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
                 me2.resetMarker(time, range, false)
                 me2.cutSelection(using: undoManager)
             }
@@ -230,8 +230,8 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
-            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[] (me2) in // @escaping
+        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
+            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[unowned undoManager] (me2) in // @escaping
                 me2.pasteAtInsertionTime(using: undoManager)
             }
             undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
@@ -261,8 +261,8 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoDeleteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
-            let redoDeleteHandler: @MainActor (MovieMutator) -> Void = {[range, time] (me2) in // @escaping
+        let undoDeleteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
+            let redoDeleteHandler: @MainActor (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
                 me2.resetMarker(time, range, false)
                 me2.deleteSelection(using: undoManager)
             }

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -198,21 +198,16 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoCutHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
-            // register redo record
-            me1.performSyncOnMainActor {
-                let redoCutHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
-                    me2.performSyncOnMainActor {
-                        me2.resetMarker(time, range, false)
-                        me2.cutSelection(using: undoManager)
-                    }
-                }
-                undoManager.registerUndo(withTarget: me1, handler: redoCutHandler)
-                undoManager.setActionName("Cut selection")
-                
-                // perform undo cut
-                me1.undoRemove(data, range, time, clip)
+        let undoCutHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
+            let redoCutHandler: @MainActor (MovieMutator) -> Void = {[range, time] (me2) in // @escaping
+                me2.resetMarker(time, range, false)
+                me2.cutSelection(using: undoManager)
             }
+            undoManager.registerUndo(withTarget: me1, handler: redoCutHandler)
+            undoManager.setActionName("Cut selection")
+            
+            // perform undo cut
+            me1.undoRemove(data, range, time, clip)
         }
         undoManager.registerUndo(withTarget: self, handler: undoCutHandler)
         undoManager.setActionName("Cut selection")
@@ -235,20 +230,15 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
-            // register redo record
-            me1.performSyncOnMainActor {
-                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[unowned undoManager] (me2) in // @escaping
-                    me2.performSyncOnMainActor {
-                        me2.pasteAtInsertionTime(using: undoManager)
-                    }
-                }
-                undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
-                undoManager.setActionName("Paste at marker")
-                
-                // perform undo paste
-                me1.undoInsert(data, range, time, clip)
+        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
+            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[] (me2) in // @escaping
+                me2.pasteAtInsertionTime(using: undoManager)
             }
+            undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
+            undoManager.setActionName("Paste at marker")
+            
+            // perform undo paste
+            me1.undoInsert(data, range, time, clip)
         }
         undoManager.registerUndo(withTarget: self, handler: undoPasteHandler)
         undoManager.setActionName("Paste at marker")
@@ -271,21 +261,16 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoDeleteHandler: @Sendable (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
-            // register redo record
-            me1.performSyncOnMainActor {
-                let redoDeleteHandler: @Sendable (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
-                    me2.performSyncOnMainActor {
-                        me2.resetMarker(time, range, false)
-                        me2.deleteSelection(using: undoManager)
-                    }
-                }
-                undoManager.registerUndo(withTarget: me1, handler: redoDeleteHandler)
-                undoManager.setActionName("Delete selection")
-                
-                // perform undo delete
-                me1.undoRemove(data, range, time, clip)
+        let undoDeleteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time] (me1) in // @escaping
+            let redoDeleteHandler: @MainActor (MovieMutator) -> Void = {[range, time] (me2) in // @escaping
+                me2.resetMarker(time, range, false)
+                me2.deleteSelection(using: undoManager)
             }
+            undoManager.registerUndo(withTarget: me1, handler: redoDeleteHandler)
+            undoManager.setActionName("Delete selection")
+            
+            // perform undo delete
+            me1.undoRemove(data, range, time, clip)
         }
         undoManager.registerUndo(withTarget: self, handler: undoDeleteHandler)
         undoManager.setActionName("Delete selection")

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -51,20 +51,15 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @Sendable (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager] (me1) in // @escaping
-            // register redo replace
-            me1.performSyncOnMainActor {
-                let redoPasteHandler: @Sendable (MovieMutator) -> Void = {[movie, unowned undoManager] (me2) in // @escaping
-                    me2.performSyncOnMainActor {
-                        me2.updateFormat(movie, using: undoManager)
-                    }
-                }
-                undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
-                undoManager.setActionName("Update format")
-                
-                // perform undo replace
-                me1.undoReplace(data, range, time)
+        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, range, time, movie] (me1) in // @escaping
+            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[movie] (me2) in // @escaping
+                me2.updateFormat(movie, using: undoManager)
             }
+            undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
+            undoManager.setActionName("Update format")
+            
+            // perform undo replace
+            me1.undoReplace(data, range, time)
         }
         undoManager.registerUndo(withTarget: self, handler: undoPasteHandler)
         undoManager.setActionName("Update format")

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -51,8 +51,8 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, range, time, movie] (me1) in // @escaping
-            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[movie] (me2) in // @escaping
+        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager] (me1) in // @escaping
+            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[movie, unowned undoManager] (me2) in // @escaping
                 me2.updateFormat(movie, using: undoManager)
             }
             undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -51,17 +51,17 @@ extension MovieMutator {
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
         // register undo record
-        let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager] (me1) in // @escaping
-            let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[movie, unowned undoManager] (me2) in // @escaping
+        let undoFormatHandler: @MainActor (MovieMutator) -> Void = {[data, range, time, movie, unowned undoManager] (me1) in // @escaping
+            let redoFormatHandler: @MainActor (MovieMutator) -> Void = {[movie, unowned undoManager] (me2) in // @escaping
                 me2.updateFormat(movie, using: undoManager)
             }
-            undoManager.registerUndo(withTarget: me1, handler: redoPasteHandler)
+            undoManager.registerUndo(withTarget: me1, handler: redoFormatHandler)
             undoManager.setActionName("Update format")
             
             // perform undo replace
             me1.undoReplace(data, range, time)
         }
-        undoManager.registerUndo(withTarget: self, handler: undoPasteHandler)
+        undoManager.registerUndo(withTarget: self, handler: undoFormatHandler)
         undoManager.setActionName("Update format")
         
         // perform replacement

--- a/cutter2/Models/MovieMutator.swift
+++ b/cutter2/Models/MovieMutator.swift
@@ -31,7 +31,7 @@ final class UndoManagerWrapper {
     
     func registerUndo<T: AnyObject>(
         withTarget target: T,
-        handler: @Sendable @escaping (T) -> Void
+        handler: @MainActor @escaping (T) -> Void
     ) {
         undoManager.registerUndo(withTarget: target, handler: handler)
     }
@@ -42,26 +42,6 @@ final class UndoManagerWrapper {
     
     func removeAllActions(withTarget target: AnyObject) {
         undoManager.removeAllActions(withTarget: target)
-    }
-}
-
-extension MovieMutator {
-    
-    /// Runs a throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A closure isolated to the main actor that may throw an error.
-    /// - Returns: The result of the closure's operation.
-    /// - Throws: Any error thrown by the closure.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () throws -> T) throws -> T {
-        return try ActorUtilities.performSyncOnMainActor(block)
-    }
-    
-    /// Runs a non-throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A non-throwing closure isolated to the main actor.
-    /// - Returns: The result of the closure's operation.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () -> T) -> T {
-        return ActorUtilities.performSyncOnMainActor(block)
     }
 }
 

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -10,30 +10,6 @@ import Cocoa
 import AVFoundation
 
 /* ============================================ */
-// MARK: - Actor isolation
-/* ============================================ */
-
-extension CAPARViewController {
-    
-    /// Runs a throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A closure isolated to the main actor that may throw an error.
-    /// - Returns: The result of the closure's operation.
-    /// - Throws: Any error thrown by the closure.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () throws -> T) throws -> T {
-        return try ActorUtilities.performSyncOnMainActor(block)
-    }
-    
-    /// Runs a non-throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A non-throwing closure isolated to the main actor.
-    /// - Returns: The result of the closure's operation.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () -> T) -> T {
-        return ActorUtilities.performSyncOnMainActor(block)
-    }
-}
-
-/* ============================================ */
 
 @MainActor
 class CAPARViewController: NSViewController {
@@ -97,13 +73,13 @@ class CAPARViewController: NSViewController {
             
             guard let self else { return }
             guard
-                let sheetWindow = performSyncOnMainActor({ self.view.window }),
+                let sheetWindow = ActorUtilities.performSyncOnMainActor({ self.view.window }),
                 let control = notification.object as? NSControl,
-                let controlWindow = performSyncOnMainActor({ control.window }),
+                let controlWindow = ActorUtilities.performSyncOnMainActor({ control.window }),
                 sheetWindow == controlWindow
             else { return }
             
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 updateStruct()
                 updateLabels(self)
             }

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -68,7 +68,7 @@ extension ViewController {
             }
             
             // After Live resize we needs tracking area update
-            ActorUtilities.performSyncOnMainActor{
+            ActorUtilities.performSyncOnMainActor {
                 self.timelineView.needsUpdateTrackingArea = true
                 self.timelineView.needsLayout = true
             }

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -41,7 +41,7 @@ extension ViewController {
         
         if keyPath == keyPathStepMode, let newNumber = newAny as? NSNumber {
             let new: Bool = !newNumber.boolValue
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 if mimicJKLcombination != new {
                     mimicJKLcombination = new
                     
@@ -60,7 +60,7 @@ extension ViewController {
             
             guard let self else { return }
             guard
-                let vcWindow = performSyncOnMainActor({ self.view.window }),
+                let vcWindow = ActorUtilities.performSyncOnMainActor({ self.view.window }),
                 let object = notification.object as? NSWindow,
                 vcWindow == object
             else {
@@ -68,7 +68,7 @@ extension ViewController {
             }
             
             // After Live resize we needs tracking area update
-            performSyncOnMainActor{
+            ActorUtilities.performSyncOnMainActor{
                 self.timelineView.needsUpdateTrackingArea = true
                 self.timelineView.needsLayout = true
             }
@@ -106,7 +106,7 @@ extension ViewController {
             
             guard let self else { return }
             guard
-                let delegate = performSyncOnMainActor({ self.delegate }),
+                let delegate = ActorUtilities.performSyncOnMainActor({ self.delegate }),
                 let object = notification.object as? ViewControllerDelegate,
                 object === delegate // ViewControllerDelegate is not Equatable
             else { return }
@@ -120,7 +120,7 @@ extension ViewController {
                 let duration = (userInfo[durationInfoKey] as? NSNumber)?.doubleValue
             else { return }
             let valid = duration > 0.0
-            performSyncOnMainActor {
+            ActorUtilities.performSyncOnMainActor {
                 updateTimeline(current: Float64(curPosition),
                                from: Float64(startPosition),
                                to: Float64(endPosition),

--- a/cutter2/ViewControllers/ViewController.swift
+++ b/cutter2/ViewControllers/ViewController.swift
@@ -10,30 +10,6 @@ import Cocoa
 import AVFoundation
 
 /* ============================================ */
-// MARK: - Actor isolation
-/* ============================================ */
-
-extension ViewController {
-    
-    /// Runs a throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A closure isolated to the main actor that may throw an error.
-    /// - Returns: The result of the closure's operation.
-    /// - Throws: Any error thrown by the closure.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () throws -> T) throws -> T {
-        return try ActorUtilities.performSyncOnMainActor(block)
-    }
-    
-    /// Runs a non-throwing `@MainActor`-isolated closure synchronously.
-    /// - Parameter block: A non-throwing closure isolated to the main actor.
-    /// - Returns: The result of the closure's operation.
-    /// - Warning: Blocks the calling thread if not already on the main thread, potentially causing UI freezes.
-    nonisolated func performSyncOnMainActor<T: Sendable>(_ block: @MainActor () -> T) -> T {
-        return ActorUtilities.performSyncOnMainActor(block)
-    }
-}
-
-/* ============================================ */
 
 extension Notification.Name {
     static let timelineUpdateReq = Notification.Name("timelineUpdateReq")


### PR DESCRIPTION
## Refactor S-01 / S-02: UndoManagerWrapper @MainActor handler + remove duplicate wrappers

### S-02: UndoManagerWrapper.registerUndo handler switched to @MainActor

Changed `UndoManagerWrapper.registerUndo`'s handler signature from `@Sendable` to `@MainActor`. Migrated the undo/redo handlers in `MovieMutator+Edit.swift` (cut/paste/delete) and `MovieMutator+Transform.swift` (updateFormat) to use `@MainActor` closures.

**Removed as a result:**

- 8 `unowned undoManager` captures
- 8 `me1.performSyncOnMainActor` / `me2.performSyncOnMainActor` nested calls

### S-01: Remove duplicate `performSyncOnMainActor` wrappers

Removed the thin extension wrappers from `Document`, `ViewController`, `CAPARViewController`, and `MovieMutator`. Migrated all 18 call sites across the Document and ViewController extensions to call `ActorUtilities.performSyncOnMainActor` directly.

### Files changed

- `cutter2/Models/MovieMutator.swift` — wrapper removal + registerUndo signature change
- `cutter2/Models/MovieMutator+Edit.swift` — cut/paste/delete handlers converted to @MainActor
- `cutter2/Models/MovieMutator+Transform.swift` — updateFormat handler converted to @MainActor
- `cutter2/Document/Document+ActorIsolation.swift` — wrapper removal
- `cutter2/Document/Document+FileIO.swift` — 3 call sites migrated
- `cutter2/Document/Document+Observers.swift` — 5 call sites migrated
- `cutter2/Document/Document+SavePanel.swift` — 1 call site migrated
- `cutter2/Document/Document+SheetControl.swift` — 1 call site migrated
- `cutter2/Document/Document+UI.swift` — 2 call sites migrated
- `cutter2/ViewControllers/ViewController.swift` — wrapper removal
- `cutter2/ViewControllers/ViewController+Observer.swift` — 5 call sites migrated
- `cutter2/ViewControllers/CAPARViewController.swift` — wrapper removal + 3 call sites migrated

### Verification

- Xcode Build / Analyze: SUCCEEDED
- All tests (148 tests): SUCCEEDED
- `grep 'func performSyncOnMainActor'` — only ActorUtilities.swift remains
- `grep 'unowned undoManager'` — 8 matches across MovieMutator+Edit.swift and MovieMutator+Transform.swift (retained intentionally)
- `grep 'me[12]\.performSyncOnMainActor'` — no matches

### Plan references

- `/_plans/S-01_performSyncOnMainActor_duplicate_plan.md`
- `/_plans/S-02_UndoManagerWrapper_migration_plan.md`
