### PR TITLE
Fix S-10: guard let for window and playerView in Document+UI.swift

### DIFF
--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -139,6 +139,8 @@ extension Document {
         
         guard let mutator = self.movieMutator else { NSSound.beep(); return }
         guard let dict: [AnyHashable:Any] = mutator.clappaspDictionary() else { NSSound.beep(); return }
+        // S-10: guard let for window (early-bail before storyboard instantiation)
+        guard let window = self.window else { NSSound.beep(); return }
         
         // Prepare CAPAR SheetController
         let storyboard: NSStoryboard = NSStoryboard(name: "Main", bundle: nil)
@@ -154,8 +156,6 @@ extension Document {
         guard caparVC.applySource(dict) else { return }
         
         // Show CAPAR Sheet
-        // S-10: guard let for window
-        guard let window = self.window else { NSSound.beep(); return }
         caparVC.beginSheetModal(for: window) {[caparVC, mutator, weak self] (response) in // @escaping
             self?.afterSheetContinue(response) { document in
                 // Update Clap/Pasp settings

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -41,8 +41,10 @@ extension Document {
         guard let mutator = self.movieMutator else { return }
         // S-10: guard let for window and playerView
         guard let window = self.window, let playerView = self.playerView else { return }
+        // S-10 follow-up: NSWindow.screen is also Optional (nil when offscreen / teardown)
+        guard let screen = window.screen else { return }
         
-        let screenRect = window.screen!.visibleFrame
+        let screenRect = screen.visibleFrame
         let viewSize = playerView.frame.size
         let windowSize = window.frame.size
         let extraSize = NSSize(width: windowSize.width - viewSize.width,

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -22,11 +22,13 @@ extension Document {
     public func displayRatio(_ baseSize: CGSize?) -> CGFloat {
         
         guard let mutator = self.movieMutator else { return 1.0 }
+        // S-10: guard let for playerView (Optional AVPlayerView?)
+        guard let playerView = self.playerView else { return 1.0 }
         
         let size = baseSize ?? mutator.dimensions(of: self.dimensionsType)
         if size == NSZeroSize { return 1.0 }
         
-        let viewSize = playerView!.frame.size
+        let viewSize = playerView.frame.size
         let hRatio = viewSize.width / size.width
         let vRatio = viewSize.height / size.height
         let ratio = (hRatio < vRatio) ? hRatio: vRatio
@@ -37,10 +39,12 @@ extension Document {
     @IBAction func resizeWindow(_ sender: Any?) {
         
         guard let mutator = self.movieMutator else { return }
+        // S-10: guard let for window and playerView
+        guard let window = self.window, let playerView = self.playerView else { return }
         
-        let screenRect = window!.screen!.visibleFrame
-        let viewSize = playerView!.frame.size
-        let windowSize = window!.frame.size
+        let screenRect = window.screen!.visibleFrame
+        let viewSize = playerView.frame.size
+        let windowSize = window.frame.size
         let extraSize = NSSize(width: windowSize.width - viewSize.width,
                                height: windowSize.height - viewSize.height)
         
@@ -87,7 +91,7 @@ extension Document {
         }
         
         // Transpose to anchor point
-        var origin = window!.frame.origin
+        var origin = window.frame.origin
         do {
             if keepTopLeft { // preserve top left corner
                 let newOrigin = NSPoint(x: origin.x,
@@ -122,7 +126,7 @@ extension Document {
         
         // Apply new Rect to window
         let newWindowRect = NSRect(origin: origin, size: newWindowSize)
-        window!.setFrame(newWindowRect, display: true, animate: false)
+        window.setFrame(newWindowRect, display: true, animate: false)
     }
     
     /* ============================================ */
@@ -148,7 +152,9 @@ extension Document {
         guard caparVC.applySource(dict) else { return }
         
         // Show CAPAR Sheet
-        caparVC.beginSheetModal(for: self.window!) {[caparVC, mutator, weak self] (response) in // @escaping
+        // S-10: guard let for window
+        guard let window = self.window else { NSSound.beep(); return }
+        caparVC.beginSheetModal(for: window) {[caparVC, mutator, weak self] (response) in // @escaping
             self?.afterSheetContinue(response) { document in
                 // Update Clap/Pasp settings
                 let result: [AnyHashable:Any] = caparVC.resultContent


### PR DESCRIPTION
## Fix S-10: guard let for window and playerView in Document+UI.swift

Replaces 7 force-unwrap sites (`window!` × 5, `playerView!` × 2) with `guard let` to prevent user-reachable crash when menu actions are invoked during window teardown race or before `playerView` initialization.

### Background

`Document.window` and `Document.playerView` are declared as Optional but were force-unwrapped in 7 places in `Document+UI.swift`. The force-unwrap sites were outside the scope of:

- **H-02(b)** (`fb63886`) — Document nil-guard sweep (8 sites, scope was document lifecycle paths)
- **L-01** (`as!` force-cast cleanup) — scope was Storyboard controller `as!` casts
- **M-05** (sheet bridge pattern extraction) — refactor only, did not touch force-unwraps

Surfaced as Blocker 3 in the 2026-06-20 release-prep sweep (`_plans/_review_release_blockers.md`) and tracked as S-10 in the backlog.

### Changes

- **`Document+UI.swift:displayRatio`** — `playerView!` → `guard let playerView = self.playerView else { return 1.0 }` (silent return preserves 1.0 default)
- **`Document+UI.swift:resizeWindow`** — 4 sites (`window!` × 3, `playerView!` × 1) collapsed into a single `guard let window = self.window, let playerView = self.playerView else { return }` at the top of the function
- **`Document+UI.swift:modifyClapPasp`** — `self.window!` (passed to `beginSheetModal(for:)`) → `guard let window = self.window else { NSSound.beep(); return }`, with the bound `window` passed to `beginSheetModal`. `NSSound.beep()` matches the existing user-notification idiom in the same file (line 118 / 120).

The two `window!` sites deeper in `resizeWindow` (`frame.origin` line 91, `setFrame(...)` line 129) are automatically covered by the function-level guard.

### House style alignment

The guard-let pattern matches existing nil-guard house style in the same file:
- Line 24: `guard let mutator = self.movieMutator else { return 1.0 }` (displayRatio, silent return)
- Line 118: `guard let mutator = self.movieMutator else { NSSound.beep(); return }` (modifyClapPasp, beep)
- Line 120: `guard let dict: [AnyHashable:Any] = mutator.clappaspDictionary() else { NSSound.beep(); return }` (modifyClapPasp, beep)

S-10 follows the same dispatch: silent return for read-only / automatic paths (displayRatio, resizeWindow), `NSSound.beep()` for user-initiated paths (modifyClapPasp).

### Verification

- Xcode Build: SUCCEEDED
- Xcode Analyze: SUCCEEDED
- Xcode Test: SUCCEEDED (148 / 148 passed, 0 failed)
- `grep 'window!\|playerView!' cutter2/Document/Document+UI.swift` — 0 matches
- `grep 'guard let window\|guard let playerView' cutter2/Document/Document+UI.swift` — 3 matches

### Plan reference

- `/_plans/S-10_document_ui_window_player_view_force_unwrap_plan.md`
