### PR TITLE
Fix H-06/H-07/H-08/M-17 crash hardening

### DIFF
--- a/cutter2/Application/AppDelegate.swift
+++ b/cutter2/Application/AppDelegate.swift
@@ -198,3 +198,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return data
     }
 }
+
+/// Access URLs with security-scoped bookmarks for the duration of `body`.
+/// Duplicate URLs are coalesced before access starts.
+func bracketSecurityScopedAccess<T>(
+    for urls: [URL],
+    perform body: () async throws -> T
+) async throws -> T {
+    let uniqueURLs = Array(Set(urls.map { $0.standardizedFileURL }))
+    for url in uniqueURLs {
+        _ = url.startAccessingSecurityScopedResource()
+    }
+    defer {
+        for url in uniqueURLs.reversed() {
+            url.stopAccessingSecurityScopedResource()
+        }
+    }
+    return try await body()
+}

--- a/cutter2/Application/AppDelegate.swift
+++ b/cutter2/Application/AppDelegate.swift
@@ -206,11 +206,14 @@ func bracketSecurityScopedAccess<T>(
     perform body: () async throws -> T
 ) async throws -> T {
     let uniqueURLs = Array(Set(urls.map { $0.standardizedFileURL }))
+    var startedURLs: [URL] = []
     for url in uniqueURLs {
-        _ = url.startAccessingSecurityScopedResource()
+        if url.startAccessingSecurityScopedResource() {
+            startedURLs.append(url)
+        }
     }
     defer {
-        for url in uniqueURLs.reversed() {
+        for url in startedURLs.reversed() {
             url.stopAccessingSecurityScopedResource()
         }
     }

--- a/cutter2/Application/AppDelegate.swift
+++ b/cutter2/Application/AppDelegate.swift
@@ -199,7 +199,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
-/// Access URLs with security-scoped bookmarks for the duration of `body`.
+/// Access security-scoped URLs for the duration of `body`.
 /// Duplicate URLs are coalesced before access starts.
 func bracketSecurityScopedAccess<T>(
     for urls: [URL],

--- a/cutter2/Document/Document+Utilities.swift
+++ b/cutter2/Document/Document+Utilities.swift
@@ -60,11 +60,11 @@ extension Document {
         self.removePlayerObserver()
 
         //
-        self.viewController?.cleanup()
-
-        // dealloc AVPlayer
-        self.player?.pause()
-        self.playerView?.player = nil
+        MainActor.assumeIsolated {
+            self.viewController?.cleanup()
+            self.player?.pause()
+            self.playerView?.player = nil
+        }
 
         // dealloc mutator
         self.movieMutator = nil

--- a/cutter2/Document/Document+Utilities.swift
+++ b/cutter2/Document/Document+Utilities.swift
@@ -48,7 +48,9 @@ extension Document {
     
     /// Cleanup for close document
     public func cleanup() {
-        
+        guard didCleanup == false else { return }
+        didCleanup = true
+
         //
         self.removeMutationObserver()
         self.removeAllUndoRecords()
@@ -56,14 +58,14 @@ extension Document {
         self.playerReloadTask?.cancel()
         self.playerReloadTask = nil
         self.removePlayerObserver()
-        
+
         //
         self.viewController?.cleanup()
-        
+
         // dealloc AVPlayer
         self.player?.pause()
         self.playerView?.player = nil
-        
+
         // dealloc mutator
         self.movieMutator = nil
     }

--- a/cutter2/Document/Document+Utilities.swift
+++ b/cutter2/Document/Document+Utilities.swift
@@ -60,11 +60,9 @@ extension Document {
         self.removePlayerObserver()
 
         //
-        MainActor.assumeIsolated {
-            self.viewController?.cleanup()
-            self.player?.pause()
-            self.playerView?.player = nil
-        }
+        self.viewController?.cleanup()
+        self.player?.pause()
+        self.playerView?.player = nil
 
         // dealloc mutator
         self.movieMutator = nil

--- a/cutter2/Document/Document+Utilities.swift
+++ b/cutter2/Document/Document+Utilities.swift
@@ -50,7 +50,7 @@ extension Document {
     public func cleanup() {
         guard didCleanup == false else { return }
         didCleanup = true
-
+        
         //
         self.removeMutationObserver()
         self.removeAllUndoRecords()
@@ -58,12 +58,12 @@ extension Document {
         self.playerReloadTask?.cancel()
         self.playerReloadTask = nil
         self.removePlayerObserver()
-
+        
         //
         self.viewController?.cleanup()
         self.player?.pause()
         self.playerView?.player = nil
-
+        
         // dealloc mutator
         self.movieMutator = nil
     }

--- a/cutter2/Document/Document.swift
+++ b/cutter2/Document/Document.swift
@@ -321,10 +321,9 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
         super.close()
     }
 
+    @MainActor
     deinit {
-        DispatchQueue.main.async { [weak self] in
-            self?.cleanup()
-        }
+        self.cleanup()
     }
     
     /* ============================================ */

--- a/cutter2/Document/Document.swift
+++ b/cutter2/Document/Document.swift
@@ -315,12 +315,12 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
     }
     
     internal var didCleanup: Bool = false
-
+    
     override func close() {
         cleanup()
         super.close()
     }
-
+    
     @MainActor
     deinit {
         self.cleanup()

--- a/cutter2/Document/Document.swift
+++ b/cutter2/Document/Document.swift
@@ -314,12 +314,17 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
         }
     }
     
+    internal var didCleanup: Bool = false
+
     override func close() {
-        
+        cleanup()
         super.close()
     }
-    
+
     deinit {
+        DispatchQueue.main.async { [weak self] in
+            self?.cleanup()
+        }
     }
     
     /* ============================================ */

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -50,7 +50,7 @@ extension MovieMutator {
                 try clip.insertTimeRange(movieRange, of: internalMovie, at: CMTime.zero, copySampleData: false)
             } catch {
                 LoggingSystem.video.error("\(self.ts()) \(error)")
-                preconditionFailure("ERROR: invalid clip")
+                return nil
             }
         }
         
@@ -69,7 +69,10 @@ extension MovieMutator {
             return nil
         }
         
-        precondition(validateClip(clip), "ERROR: invalid clip")
+        guard validateClip(clip) else {
+            LoggingSystem.video.error("\(self.ts()) invalid clip")
+            return nil
+        }
         return clip
     }
     

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -24,7 +24,10 @@ extension MovieMutator {
     /// - Parameter range: clip range
     /// - Returns: clip as AVMutableMovie
     internal func movieClip(_ range: CMTimeRange) -> AVMutableMovie? {
-        precondition(validateRange(range, true), "ERROR: Invalid range \(range)")
+        guard validateRange(range, true) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid range \(CMTimeGetSeconds(range.start))...\(CMTimeGetSeconds(range.end))")
+            return nil
+        }
         
         // Prepare clip
         guard let aClip = internalMovie.mutableCopy() as? AVMutableMovie else {
@@ -61,11 +64,9 @@ extension MovieMutator {
             clip.removeTimeRange(rangeBefore)
         }
         
-        if range.duration != clip.range.duration {
-            LoggingSystem.video.debug("\(self.ts()) Duration diff: \(CMTimeGetSeconds(range.duration))s vs \(CMTimeGetSeconds(clip.range.duration))s")
-            LoggingSystem.video.debug("\(self.ts()) Range duration: \(range.duration.value)/\(range.duration.timescale)")
-            LoggingSystem.video.debug("\(self.ts()) Clip range duration: \(clip.range.duration.value)/\(clip.range.duration.timescale)")
-            preconditionFailure("ERROR: invalid clip")
+        guard range.duration == clip.range.duration else {
+            LoggingSystem.video.error("\(self.ts()) invalid clip duration mismatch")
+            return nil
         }
         
         precondition(validateClip(clip), "ERROR: invalid clip")
@@ -81,8 +82,12 @@ extension MovieMutator {
     /// - Parameters:
     ///   - range: Range to remove
     ///   - time: insertionTime
-    private func doRemove(_ range: CMTimeRange, _ time: CMTime) {
-        precondition(validateRange(range, true), "ERROR: Invalid range \(range)")
+    /// - Returns: true if the removal succeeded
+    private func doRemove(_ range: CMTimeRange, _ time: CMTime) -> Bool {
+        guard validateRange(range, true) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid range \(CMTimeGetSeconds(range.start))...\(CMTimeGetSeconds(range.end))")
+            return false
+        }
         
         // perform delete selection
         do {
@@ -94,6 +99,7 @@ extension MovieMutator {
                                    : time - range.duration)
             let newRange: CMTimeRange = CMTimeRangeMake(start: range.start, duration: CMTime.zero)
             resetMarker(newTime, newRange, true)
+            return true
         }
     }
     
@@ -105,10 +111,16 @@ extension MovieMutator {
     ///   - time: original insertionTime
     ///   - clip: removed clip data
     private func undoRemove(_ data: Data, _ range: CMTimeRange, _ time: CMTime, _ clip: Data) {
-        precondition(validateClipData(clip), "ERROR: Invalid clip data")
+        guard validateClipData(clip) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid clip data for undo remove")
+            return
+        }
         
         let reloadDone: Bool = reloadAndNotify(from: data, range: range, time: time)
-        precondition(reloadDone, "ERROR: Failed to reload movie")
+        guard reloadDone else {
+            LoggingSystem.video.error("\(self.ts()) Failed to reload movie for undo remove")
+            return
+        }
     }
     
     /// Insert clip at insertionTime. Adjust insertionTime/selection.
@@ -116,10 +128,13 @@ extension MovieMutator {
     /// - Parameters:
     ///   - clip: clip data to insert
     ///   - time: insertionTime
-    private func doInsert(_ clip: Data, _ time: CMTime) {
+    /// - Returns: true if the insertion succeeded
+    private func doInsert(_ clip: Data, _ time: CMTime) -> Bool {
         let clip = AVMutableMovie(data: clip, options: nil)
-        precondition(validateClip(clip), "ERROR: Invalid clip data")
-        precondition(validateTime(time), "ERROR: Invalid insertion time")
+        guard validateClip(clip), validateTime(time) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid insert request")
+            return false
+        }
         
         // perform insert clip at marker
         do {
@@ -146,9 +161,10 @@ extension MovieMutator {
             let newTime: CMTime = time + actualDelta
             let newRange: CMTimeRange = CMTimeRangeMake(start: time, duration: actualDelta)
             resetMarker(newTime, newRange, true)
+            return true
         } catch {
             LoggingSystem.video.error("Failed to insert clip: \(error.localizedDescription)")
-            preconditionFailure("ERROR: failed to insert clip")
+            return false
         }
     }
     
@@ -160,14 +176,23 @@ extension MovieMutator {
     ///   - time: original insertionTime
     ///   - clip: inserted clip data
     private func undoInsert(_ data: Data, _ range: CMTimeRange, _ time: CMTime, _ clip: Data) {
-        precondition(validateClipData(clip), "ERROR: invalid clip data")
+        guard validateClipData(clip) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid clip data for undo insert")
+            return
+        }
         
         // populate PBoard with original clip
         let pbDone: Bool = writeClipToPBoard(clip)
-        precondition(pbDone, "ERROR: failed to populate PBoard")
+        guard pbDone else {
+            LoggingSystem.video.error("\(self.ts()) Failed to populate PBoard for undo insert")
+            return
+        }
         
         let reloadDone: Bool = reloadAndNotify(from: data, range: range, time: time)
-        precondition(reloadDone, "ERROR: failed to reload movie")
+        guard reloadDone else {
+            LoggingSystem.video.error("\(self.ts()) Failed to reload movie for undo insert")
+            return
+        }
     }
     
     /* ============================================ */
@@ -182,7 +207,10 @@ extension MovieMutator {
         guard validateRange(range, true) else { NSSound.beep(); return; }
         
         let pbDone = (writeRangeToPBoard(range) != nil)
-        precondition(pbDone, "ERROR: failed to copy selection")
+        guard pbDone else {
+            NSSound.beep()
+            return
+        }
     }
     
     /// Cut selection of internalMovie
@@ -197,7 +225,14 @@ extension MovieMutator {
         guard let clip = writeRangeToPBoard(range) else { NSSound.beep(); return; }
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
-        // register undo record
+        // perform cut first
+        guard self.doRemove(range, time) else {
+            NSSound.beep()
+            return
+        }
+        refreshMovie()
+        
+        // register undo record (only after successful mutation)
         let undoCutHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             let redoCutHandler: @MainActor (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
                 me2.resetMarker(time, range, false)
@@ -211,10 +246,6 @@ extension MovieMutator {
         }
         undoManager.registerUndo(withTarget: self, handler: undoCutHandler)
         undoManager.setActionName("Cut selection")
-        
-        // perform cut
-        self.doRemove(range, time)
-        refreshMovie()
     }
     
     /// Paste clip into internalMovie
@@ -229,7 +260,14 @@ extension MovieMutator {
         guard let clip = readClipFromPBoard() else { NSSound.beep(); return; }
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
-        // register undo record
+        // perform paste first
+        guard self.doInsert(clip, time) else {
+            NSSound.beep()
+            return
+        }
+        refreshMovie()
+        
+        // register undo record (only after successful mutation)
         let undoPasteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             let redoPasteHandler: @MainActor (MovieMutator) -> Void = {[unowned undoManager] (me2) in // @escaping
                 me2.pasteAtInsertionTime(using: undoManager)
@@ -242,10 +280,6 @@ extension MovieMutator {
         }
         undoManager.registerUndo(withTarget: self, handler: undoPasteHandler)
         undoManager.setActionName("Paste at marker")
-        
-        // perform paste
-        self.doInsert(clip, time)
-        refreshMovie()
     }
     
     /// Delete selection of internalMovie
@@ -260,7 +294,14 @@ extension MovieMutator {
         guard let clip = movieClip(range)?.movHeader else { NSSound.beep(); return; }
         guard let data = internalMovie.movHeader else { NSSound.beep(); return; }
         
-        // register undo record
+        // perform delete first
+        guard self.doRemove(range, time) else {
+            NSSound.beep()
+            return
+        }
+        refreshMovie()
+        
+        // register undo record (only after successful mutation)
         let undoDeleteHandler: @MainActor (MovieMutator) -> Void = {[data, clip, range, time, unowned undoManager] (me1) in // @escaping
             let redoDeleteHandler: @MainActor (MovieMutator) -> Void = {[range, time, unowned undoManager] (me2) in // @escaping
                 me2.resetMarker(time, range, false)
@@ -274,9 +315,5 @@ extension MovieMutator {
         }
         undoManager.registerUndo(withTarget: self, handler: undoDeleteHandler)
         undoManager.setActionName("Delete selection")
-        
-        // perform delete
-        self.doRemove(range, time)
-        refreshMovie()
     }
 }

--- a/cutter2/Models/MovieMutatorBase.swift
+++ b/cutter2/Models/MovieMutatorBase.swift
@@ -193,8 +193,10 @@ class MovieMutatorBase: NSObject {
     ///   - notify: trigger notification for GUI update
     public func resetMarker(_ time: CMTime, _ range: CMTimeRange, _ notify: Bool) {
         
-        precondition(validateRange(range, false), "ERROR: Invalid range: \(range)")
-        precondition(validateTime(time), "ERROR: Invalid time: \(time)")
+        guard validateRange(range, false), validateTime(time) else {
+            LoggingSystem.video.error("\(self.ts()) Invalid marker state: time=\(CMTimeGetSeconds(time)) range=\(CMTimeGetSeconds(range.start))...\(CMTimeGetSeconds(range.end))")
+            return
+        }
         
         insertionTime = time
         selectedTimeRange = range

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -550,46 +550,47 @@ extension MovieWriter {
         
         /* ============================================ */
         
-        // Initialize asset reader and writer.
+        // Initialize and run export with security-scoped access bracket for reference media
         let movie: AVMutableMovie = internalMovie
         let startTime: CMTime = movie.range.start
         let endTime: CMTime = movie.range.end
-        var ar: AVAssetReader
-        var aw: AVAssetWriter
-        do {
-            ar = try AVAssetReader(asset: movie)
-            aw = try AVAssetWriter(url: url, fileType: type)
-        } catch {
-            try throwError(.assetReaderWriterUnavailable, reason: "Failed to create AVAssetReader or AVAssetWriter.")
-        }
-        
-        // Configure asset reader and writer.
-        do {
-            // Set writer parameters.
-            aw.movieTimeScale = movie.timescale
-            aw.movieFragmentInterval = CMTime.invalid
-            aw.shouldOptimizeForNetworkUse = true
-            
-            // Prepare media channels.
-            try prepareAudioChannels(movie, ar, aw)
-            prepareVideoChannels(movie, ar, aw)
-            prepareOtherMediaChannels(movie, ar, aw)
-            
-            // Begin reading and writing.
-            let readyReader: Bool = ar.startReading()
-            let readyWriter: Bool = aw.startWriting()
-            guard readyReader && readyWriter else {
-                let error = (readyReader == false) ? ar.error : aw.error
-                ar.cancelReading()
-                aw.cancelWriting()
-                try throwError(.assetReaderWriterFailed, reason: error.debugDescription)
+        let referenceURLs: [URL] = internalMovie.findReferenceURLs() ?? []
+        try await bracketSecurityScopedAccess(for: referenceURLs) {
+            var ar: AVAssetReader
+            var aw: AVAssetWriter
+            do {
+                ar = try AVAssetReader(asset: movie)
+                aw = try AVAssetWriter(url: url, fileType: type)
+            } catch {
+                try throwError(.assetReaderWriterUnavailable, reason: "Failed to create AVAssetReader or AVAssetWriter.")
             }
+            
+            // Configure asset reader and writer.
+            do {
+                // Set writer parameters.
+                aw.movieTimeScale = movie.timescale
+                aw.movieFragmentInterval = CMTime.invalid
+                aw.shouldOptimizeForNetworkUse = true
+                
+                // Prepare media channels.
+                try prepareAudioChannels(movie, ar, aw)
+                prepareVideoChannels(movie, ar, aw)
+                prepareOtherMediaChannels(movie, ar, aw)
+                
+                // Begin reading and writing.
+                let readyReader: Bool = ar.startReading()
+                let readyWriter: Bool = aw.startWriting()
+                guard readyReader && readyWriter else {
+                    let error = (readyReader == false) ? ar.error : aw.error
+                    ar.cancelReading()
+                    aw.cancelWriting()
+                    try throwError(.assetReaderWriterFailed, reason: error.debugDescription)
+                }
+            }
+            
+            // Export using the async method.
+            await exportCustomMovieCore(ar: ar, aw: aw, startTime: startTime, endTime: endTime, dateStart: dateStart)
         }
-        
-        /* ============================================ */
-        
-        // Export using the async method.
-        await exportCustomMovieCore(ar: ar, aw: aw, startTime: startTime, endTime: endTime, dateStart: dateStart)
         
         // If export failed, throw the error.
         if writeSuccess == false {

--- a/cutter2/Models/MovieWriter+ExportSession.swift
+++ b/cutter2/Models/MovieWriter+ExportSession.swift
@@ -264,46 +264,49 @@ extension MovieWriter {
         
         /* ============================================ */
         
-        // Start ExportSession
-        if #available(macOS 15, *) {
-            do {
-                try await exportSession.export(to: url, as: type, isolation: #isolation)
-                let dateEnd = Date()
-                finalizeExport(startedAt: dateStart,
-                               endedAt: dateEnd,
-                               progress: 1.0,
-                               status: .completed,
-                               error: nil)
-            } catch {
-                let dateEnd = Date()
-                let nsError = error as NSError
-                let cancelled = writeCancelled || nsError.code == NSUserCancelledError
-                let status: AVAssetExportSession.Status = (cancelled ? .cancelled : .failed)
-                finalizeExport(startedAt: dateStart,
-                               endedAt: dateEnd,
-                               progress: self.writeProgress,
-                               status: status,
-                               error: cancelled ? nil : error)
-            }
-        } else {
-            exportSession.outputFileType = type
-            exportSession.outputURL = url
-            
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                exportSession.exportAsynchronously { @Sendable in
-                    continuation.resume()
+        // Start ExportSession with security-scoped access bracket for reference media
+        let referenceURLs: [URL] = internalMovie.findReferenceURLs() ?? []
+        try await bracketSecurityScopedAccess(for: referenceURLs) {
+            if #available(macOS 15, *) {
+                do {
+                    try await exportSession.export(to: url, as: type, isolation: #isolation)
+                    let dateEnd = Date()
+                    finalizeExport(startedAt: dateStart,
+                                   endedAt: dateEnd,
+                                   progress: 1.0,
+                                   status: .completed,
+                                   error: nil)
+                } catch {
+                    let dateEnd = Date()
+                    let nsError = error as NSError
+                    let cancelled = writeCancelled || nsError.code == NSUserCancelledError
+                    let status: AVAssetExportSession.Status = (cancelled ? .cancelled : .failed)
+                    finalizeExport(startedAt: dateStart,
+                                   endedAt: dateEnd,
+                                   progress: self.writeProgress,
+                                   status: status,
+                                   error: cancelled ? nil : error)
                 }
+            } else {
+                exportSession.outputFileType = type
+                exportSession.outputURL = url
+                
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    exportSession.exportAsynchronously { @Sendable in
+                        continuation.resume()
+                    }
+                }
+                
+                let progress: Float = exportSession.progress
+                let dateEnd: Date = Date()
+                let result: AVAssetExportSession.Status = exportSession.status
+                let error: Error? = (result == .cancelled ? nil : exportSession.error)
+                finalizeExport(startedAt: dateStart,
+                               endedAt: dateEnd,
+                               progress: progress,
+                               status: result,
+                               error: error)
             }
-            
-            let progress: Float = exportSession.progress
-            let dateEnd: Date = Date()
-            let result: AVAssetExportSession.Status = exportSession.status
-            let error: Error? = (result == .cancelled ? nil : exportSession.error)
-            finalizeExport(startedAt: dateStart,
-                           endedAt: dateEnd,
-                           progress: progress,
-                           status: result,
-                           error: error)
         }
         
         //

--- a/cutter2/Models/MovieWriter+WriteMovie.swift
+++ b/cutter2/Models/MovieWriter+WriteMovie.swift
@@ -123,50 +123,53 @@ extension MovieWriter {
         
         /* ============================================ */
         
-        // Start flatten movie
-        do {
-            var success: Bool = false
-            let cancel: Bool = self.writeCancelled
-            var error: Error? = nil
-            
-            // Insert sampleData to destination first
-            try newMovie.insertTimeRange(range,
-                                         of: movie,
-                                         at: CMTime.zero,
-                                         copySampleData: selfContained)
-            
-            // Write movieHeader to destination
-            try newMovie.writeHeader(to: url, fileType: AVFileType.mov, options: option)
-            
-            //
-            success = true
-            error = nil
-            
-            //
-            let progress: Float = 1.0
-            let dateEnd: Date = Date()
-            let interval: TimeInterval = dateEnd.timeIntervalSince(dateStart)
-            
-            // Update Properties
-            self.writeSuccess = success
-            self.writeError = error
-            self.writeCancelled = cancel
-            self.writeStart = dateStart
-            self.writeEnd = dateEnd
-            self.writeProgress = 1.0
-            
-            //
-            let status = "completed" // (success ? "completed" : (cancel ? "cancelled" : "failed"))
-            let progressStr = String(format:"%.2f",progress * 100)
-            let intervalStr = String(format:"%.2f",interval)
-            if let error = self.writeError {
-                LoggingSystem.export.error("Result: \(status), progress: \(progressStr), elapsed: \(intervalStr), error: \(error)")
-            } else {
-                LoggingSystem.export.notice("Result: \(status), progress: \(progressStr), elapsed: \(intervalStr)")
+        // Start flatten movie with security-scoped access bracket for reference media
+        let referenceURLs: [URL] = internalMovie.findReferenceURLs() ?? []
+        try await bracketSecurityScopedAccess(for: referenceURLs) {
+            do {
+                var success: Bool = false
+                let cancel: Bool = self.writeCancelled
+                var error: Error? = nil
+                
+                // Insert sampleData to destination first
+                try newMovie.insertTimeRange(range,
+                                             of: movie,
+                                             at: CMTime.zero,
+                                             copySampleData: selfContained)
+                
+                // Write movieHeader to destination
+                try newMovie.writeHeader(to: url, fileType: AVFileType.mov, options: option)
+                
+                //
+                success = true
+                error = nil
+                
+                //
+                let progress: Float = 1.0
+                let dateEnd: Date = Date()
+                let interval: TimeInterval = dateEnd.timeIntervalSince(dateStart)
+                
+                // Update Properties
+                self.writeSuccess = success
+                self.writeError = error
+                self.writeCancelled = cancel
+                self.writeStart = dateStart
+                self.writeEnd = dateEnd
+                self.writeProgress = 1.0
+                
+                //
+                let status = "completed" // (success ? "completed" : (cancel ? "cancelled" : "failed"))
+                let progressStr = String(format:"%.2f",progress * 100)
+                let intervalStr = String(format:"%.2f",interval)
+                if let error = self.writeError {
+                    LoggingSystem.export.error("Result: \(status), progress: \(progressStr), elapsed: \(intervalStr), error: \(error)")
+                } else {
+                    LoggingSystem.export.notice("Result: \(status), progress: \(progressStr), elapsed: \(intervalStr)")
+                }
+            } catch {
+                let reason = "Failed to write movie: \(option)."
+                try throwError(.movieWriterFailed, reason: reason)
             }
-        } catch {
-            let reason = "Failed to write movie: \(option)."
-            try throwError(.movieWriterFailed, reason: reason)
         }
         
         /* ============================================ */

--- a/cutter2/ViewControllers/TranscodeViewController.swift
+++ b/cutter2/ViewControllers/TranscodeViewController.swift
@@ -88,7 +88,7 @@ class TranscodeViewController: NSViewController {
                                   AVAssetExportPreset3840x2160,
                                   AVAssetExportPresetHEVC1920x1080,
                                   AVAssetExportPresetHEVC3840x2160]
-            preset = name[preset0]
+            preset = name[min(max(preset0, 0), name.count - 1)]
             fileType = .mov
         case 1:
             let preset1: Int = UserDefaults.standard.integer(forKey: kTrancode1Key)
@@ -96,7 +96,7 @@ class TranscodeViewController: NSViewController {
                                   AVAssetExportPresetMediumQuality,
                                   AVAssetExportPresetHighestQuality,
                                   AVAssetExportPresetHEVCHighestQuality]
-            preset = name[preset1]
+            preset = name[min(max(preset1, 0), name.count - 1)]
             fileType = .mov
         case 2:
             //let preset2: Int = UserDefaults.standard.integer(forKey: kTrancode2Key)
@@ -111,7 +111,7 @@ class TranscodeViewController: NSViewController {
                                   AVAssetExportPresetAppleM4VWiFi,
                                   AVAssetExportPresetAppleM4V720pHD,
                                   AVAssetExportPresetAppleM4V1080pHD]
-            preset = name[preset3]
+            preset = name[min(max(preset3, 0), name.count - 1)]
             fileType = .m4v
         case 4:
             preset = kTranscodePresetCustom


### PR DESCRIPTION
This PR hardens four crash-prone paths:

- H-06: brackets reference-media I/O with security-scoped access during write/export.
- H-07: makes Document cleanup run from deinit and keeps teardown idempotent.
- H-08: clamps transcode preset indices before array access.
- M-17: removes user-triggered trap paths from MovieMutator edit validation and keeps undo registration after successful mutation only.

Validation:
- xcodebuild build — SUCCEEDED
- xcodebuild analyze — SUCCEEDED