### PR TITLE
Fix M-11, M-12, M-14, and M-16: harden save/export observers and undo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build/
 DerivedData/
 .build/
+.derivedData/
 
 ## Various settings
 *.pbxuser

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -376,7 +376,7 @@ extension Document {
         
         // SaveAs triggers internal movie refresh (to sync selfcontained <> referece movie change)
         guard let url = self.fileURL else { return }
-        guard let newMovie = AVMutableMovie(url: url, options: nil) else { return }
+        let newMovie = AVMutableMovie(url: url, options: nil)
         guard let mutator = self.movieMutator else { return }
         let time: CMTime = mutator.insertionTime
         let range: CMTimeRange = mutator.selectedTimeRange

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -375,27 +375,20 @@ extension Document {
     private func refreshMutator() {
         
         // SaveAs triggers internal movie refresh (to sync selfcontained <> referece movie change)
-        Task { @MainActor [weak self] in
-            
-            guard let self else { return }
-            guard let url: URL = self.fileURL else { preconditionFailure("Unexpected nil fileURL detected.") }
-            let newMovie: AVMutableMovie? = AVMutableMovie(url: url, options: nil)
-            if let newMovie = newMovie {
-                guard let mutator = self.movieMutator else { return }
-                let time: CMTime = mutator.insertionTime
-                let range: CMTimeRange = mutator.selectedTimeRange
-                
-                let newMovieRange: CMTimeRange = newMovie.range
-                var newTime: CMTime = CMTimeClampToRange(time, range: newMovieRange)
-                let newRange: CMTimeRange = CMTimeRangeGetIntersection(range, otherRange: newMovieRange)
-                newTime = CMTIME_IS_VALID(newTime) ? newTime : CMTime.zero
-                
-                self.removeMutationObserver()
-                self.removeAllUndoRecords()
-                self.movieMutator = MovieMutator(with: newMovie)
-                self.movieMutator?.resetMarker(newTime, newRange, true)
-                self.addMutationObserver()
-            }
+        guard let url = self.fileURL else { return }
+        guard let newMovie = AVMutableMovie(url: url, options: nil) else { return }
+        guard let mutator = self.movieMutator else { return }
+        let time: CMTime = mutator.insertionTime
+        let range: CMTimeRange = mutator.selectedTimeRange
+        
+        let newMovieRange: CMTimeRange = newMovie.range
+        var newTime: CMTime = CMTimeClampToRange(time, range: newMovieRange)
+        let newRange: CMTimeRange = CMTimeRangeGetIntersection(range, otherRange: newMovieRange)
+        newTime = CMTIME_IS_VALID(newTime) ? newTime : CMTime.zero
+        
+        guard mutator.reloadAndNotify(from: newMovie.movHeader, range: newRange, time: newTime) else {
+            LoggingSystem.fileIO.error("Failed to refresh mutator after SaveAs")
+            return
         }
     }
 }

--- a/cutter2/Document/Document+SavePanel.swift
+++ b/cutter2/Document/Document+SavePanel.swift
@@ -69,7 +69,8 @@ extension Document {
         savePanel.canSelectHiddenExtension = true
         savePanel.isExtensionHidden = false
         savePanel.delegate = self
-        savePanel.allowedContentTypes = [UTType(uti)!]
+        guard let ut = UTType(uti) else { return false }
+        savePanel.allowedContentTypes = [ut]
         savePanel.accessoryView = accessoryVC.view
         self.savePanel = savePanel
         
@@ -148,6 +149,7 @@ extension Document {
     public func didUpdateFileType(_ fileType: AVFileType, selfContained: Bool) {
         
         guard let savePanel = self.savePanel else { return }
-        savePanel.allowedContentTypes = [UTType(fileType.rawValue)!]
+        guard let ut = UTType(fileType.rawValue) else { return }
+        savePanel.allowedContentTypes = [ut]
     }
 }

--- a/cutter2/Document/Document+SavePanel.swift
+++ b/cutter2/Document/Document+SavePanel.swift
@@ -69,7 +69,10 @@ extension Document {
         savePanel.canSelectHiddenExtension = true
         savePanel.isExtensionHidden = false
         savePanel.delegate = self
-        guard let ut = UTType(uti) else { return false }
+        guard let ut = UTType(uti) else {
+            LoggingSystem.document.error("Invalid save-panel UTI: \(uti, privacy: .public)")
+            return false
+        }
         savePanel.allowedContentTypes = [ut]
         savePanel.accessoryView = accessoryVC.view
         self.savePanel = savePanel
@@ -149,7 +152,10 @@ extension Document {
     public func didUpdateFileType(_ fileType: AVFileType, selfContained: Bool) {
         
         guard let savePanel = self.savePanel else { return }
-        guard let ut = UTType(fileType.rawValue) else { return }
+        guard let ut = UTType(fileType.rawValue) else {
+            LoggingSystem.document.error("Invalid file type rawValue for save panel: \(fileType.rawValue, privacy: .public)")
+            return
+        }
         savePanel.allowedContentTypes = [ut]
     }
 }

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -66,7 +66,7 @@ extension MovieWriter {
         }
         
         guard let fourcc = customParam[kAudioCodecKey] as? NSString else {
-            preconditionFailure("kAudioCodecKey not set in customParam")
+            try throwError(.movieWriterFailed, reason: "kAudioCodecKey not set in customParam")
         }
         
         let numAudioKbps = customParam[kAudioKbpsKey] as? NSNumber
@@ -134,21 +134,20 @@ extension MovieWriter {
                             dataDst = conv.convertAsAACTag(from: dataSrc)
                         }
                     }
-                    if let data1 = dataSrc, let data2 = dataDst {
-                        data1.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-                            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-                            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-                            avacSrcLayout = AVAudioChannelLayout(layout: ptr)
-                        }
-                        data2.withUnsafeBytes {(p: UnsafeRawBufferPointer) in
-                            guard let baseAddress: UnsafeRawPointer = p.baseAddress else { preconditionFailure("ERROR: Invalid AudioChannelLayoutData") }
-                            let ptr: LayoutPtr = baseAddress.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-                            avacDstLayout = AVAudioChannelLayout(layout: ptr)
-                            numChannel = Int(avacDstLayout.channelCount)
-                        }
-                    } else {
-                        preconditionFailure("ERROR: Failed to convert layout")
+                    guard let data1 = dataSrc, let data2 = dataDst else {
+                        try throwError(.movieWriterFailed, reason: "Failed to convert layout")
                     }
+                    guard
+                        let baseAddress1 = data1.withUnsafeBytes({ $0.baseAddress }),
+                        let baseAddress2 = data2.withUnsafeBytes({ $0.baseAddress })
+                    else {
+                        try throwError(.movieWriterFailed, reason: "Invalid AudioChannelLayoutData")
+                    }
+                    let ptr1: LayoutPtr = baseAddress1.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+                    let ptr2: LayoutPtr = baseAddress2.bindMemory(to: AudioChannelLayout.self, capacity: 1)
+                    avacSrcLayout = AVAudioChannelLayout(layout: ptr1)
+                    avacDstLayout = AVAudioChannelLayout(layout: ptr2)
+                    numChannel = Int(avacDstLayout.channelCount)
                 }
                 
                 //
@@ -269,7 +268,7 @@ extension MovieWriter {
         }
     }
     
-    private func prepareVideoChannels(_ movie: AVMutableMovie, _ ar: AVAssetReader, _ aw: AVAssetWriter) {
+    private func prepareVideoChannels(_ movie: AVMutableMovie, _ ar: AVAssetReader, _ aw: AVAssetWriter) throws {
         let numVideoEncode = customParam[kVideoEncodeKey] as? NSNumber
         let videoEncode: Bool = numVideoEncode?.boolValue ?? true
         if videoEncode == false {
@@ -278,7 +277,7 @@ extension MovieWriter {
         }
         
         guard let fourcc = customParam[kVideoCodecKey] as? NSString else {
-            preconditionFailure("kVideoCodecKey not set in customParam")
+            try throwError(.movieWriterFailed, reason: "kVideoCodecKey not set in customParam")
         }
         
         let numVideoKbps = customParam[kVideoKbpsKey] as? NSNumber
@@ -574,7 +573,7 @@ extension MovieWriter {
                 
                 // Prepare media channels.
                 try prepareAudioChannels(movie, ar, aw)
-                prepareVideoChannels(movie, ar, aw)
+                try prepareVideoChannels(movie, ar, aw)
                 prepareOtherMediaChannels(movie, ar, aw)
                 
                 // Begin reading and writing.

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -137,16 +137,18 @@ extension MovieWriter {
                     guard let data1 = dataSrc, let data2 = dataDst else {
                         try throwError(.movieWriterFailed, reason: "Failed to convert layout")
                     }
-                    guard
-                        let baseAddress1 = data1.withUnsafeBytes({ $0.baseAddress }),
-                        let baseAddress2 = data2.withUnsafeBytes({ $0.baseAddress })
-                    else {
-                        try throwError(.movieWriterFailed, reason: "Invalid AudioChannelLayoutData")
+                    avacSrcLayout = try data1.withUnsafeBytes { rawPtr -> AVAudioChannelLayout in
+                        guard let base = rawPtr.baseAddress else {
+                            throw MovieWriterError.movieWriterFailed
+                        }
+                        return AVAudioChannelLayout(layout: base.bindMemory(to: AudioChannelLayout.self, capacity: 1))
                     }
-                    let ptr1: LayoutPtr = baseAddress1.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-                    let ptr2: LayoutPtr = baseAddress2.bindMemory(to: AudioChannelLayout.self, capacity: 1)
-                    avacSrcLayout = AVAudioChannelLayout(layout: ptr1)
-                    avacDstLayout = AVAudioChannelLayout(layout: ptr2)
+                    avacDstLayout = try data2.withUnsafeBytes { rawPtr -> AVAudioChannelLayout in
+                        guard let base = rawPtr.baseAddress else {
+                            throw MovieWriterError.movieWriterFailed
+                        }
+                        return AVAudioChannelLayout(layout: base.bindMemory(to: AudioChannelLayout.self, capacity: 1))
+                    }
                     numChannel = Int(avacDstLayout.channelCount)
                 }
                 

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -139,13 +139,13 @@ extension MovieWriter {
                     }
                     avacSrcLayout = try data1.withUnsafeBytes { rawPtr -> AVAudioChannelLayout in
                         guard let base = rawPtr.baseAddress else {
-                            throw MovieWriterError.movieWriterFailed
+                            try throwError(.movieWriterFailed, reason: "Invalid AudioChannelLayoutData")
                         }
                         return AVAudioChannelLayout(layout: base.bindMemory(to: AudioChannelLayout.self, capacity: 1))
                     }
                     avacDstLayout = try data2.withUnsafeBytes { rawPtr -> AVAudioChannelLayout in
                         guard let base = rawPtr.baseAddress else {
-                            throw MovieWriterError.movieWriterFailed
+                            try throwError(.movieWriterFailed, reason: "Invalid AudioChannelLayoutData")
                         }
                         return AVAudioChannelLayout(layout: base.bindMemory(to: AudioChannelLayout.self, capacity: 1))
                     }

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -12,7 +12,22 @@ import AVFoundation
 /* ============================================ */
 
 private final class ObserverTokenBox: @unchecked Sendable {
-    var token: NSObjectProtocol? = nil
+    private let lock = NSLock()
+    private var token: NSObjectProtocol? = nil
+    
+    func store(_ token: NSObjectProtocol?) {
+        lock.lock()
+        self.token = token
+        lock.unlock()
+    }
+    
+    func take() -> NSObjectProtocol? {
+        lock.lock()
+        defer { lock.unlock() }
+        let token = self.token
+        self.token = nil
+        return token
+    }
 }
 
 /* ============================================ */
@@ -100,7 +115,7 @@ class CAPARViewController: NSViewController {
                                           object: nil,
                                           queue: OperationQueue.main,
                                           using: textHandler)
-            self.textObserver.token = observer
+            self.textObserver.store(observer)
         }
     }
     
@@ -114,20 +129,18 @@ class CAPARViewController: NSViewController {
         removeTextObserver()
     }
     
-    private func removeTextObserver() {
-        guard let observer = self.textObserver.token else { return }
+    private nonisolated func removeTextObserver() {
+        guard let observer = self.textObserver.take() else { return }
         NotificationCenter.default.removeObserver(observer,
                                                   name: NSControl.textDidChangeNotification,
                                                   object: nil)
-        self.textObserver.token = nil
     }
     
     deinit {
-        guard let observer = textObserver.token else { return }
+        guard let observer = textObserver.take() else { return }
         NotificationCenter.default.removeObserver(observer,
                                                   name: NSControl.textDidChangeNotification,
                                                   object: nil)
-        textObserver.token = nil
     }
     
     /* ============================================ */

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -30,7 +30,7 @@ class CAPARViewController: NSViewController {
     /* ============================================ */
     
     private var parentWindow: NSWindow? = nil
-    private var textObserver: NSObjectProtocol? = nil
+    private nonisolated(unsafe) var textObserver: NSObjectProtocol? = nil
     
     /* ============================================ */
     // MARK: - Sheet control
@@ -117,7 +117,10 @@ class CAPARViewController: NSViewController {
     }
     
     deinit {
-        removeTextObserver()
+        guard let observer = textObserver else { return }
+        NotificationCenter.default.removeObserver(observer,
+                                                  name: NSControl.textDidChangeNotification,
+                                                  object: nil)
     }
     
     /* ============================================ */

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -11,6 +11,12 @@ import AVFoundation
 
 /* ============================================ */
 
+private final class ObserverTokenBox: @unchecked Sendable {
+    var token: NSObjectProtocol? = nil
+}
+
+/* ============================================ */
+
 @MainActor
 class CAPARViewController: NSViewController {
     
@@ -30,7 +36,7 @@ class CAPARViewController: NSViewController {
     /* ============================================ */
     
     private var parentWindow: NSWindow? = nil
-    private nonisolated(unsafe) var textObserver: NSObjectProtocol? = nil
+    private let textObserver = ObserverTokenBox()
     
     /* ============================================ */
     // MARK: - Sheet control
@@ -94,7 +100,7 @@ class CAPARViewController: NSViewController {
                                           object: nil,
                                           queue: OperationQueue.main,
                                           using: textHandler)
-            self.textObserver = observer
+            self.textObserver.token = observer
         }
     }
     
@@ -109,18 +115,19 @@ class CAPARViewController: NSViewController {
     }
     
     private func removeTextObserver() {
-        guard let observer = self.textObserver else { return }
+        guard let observer = self.textObserver.token else { return }
         NotificationCenter.default.removeObserver(observer,
                                                   name: NSControl.textDidChangeNotification,
                                                   object: nil)
-        self.textObserver = nil
+        self.textObserver.token = nil
     }
     
     deinit {
-        guard let observer = textObserver else { return }
+        guard let observer = textObserver.token else { return }
         NotificationCenter.default.removeObserver(observer,
                                                   name: NSControl.textDidChangeNotification,
                                                   object: nil)
+        textObserver.token = nil
     }
     
     /* ============================================ */

--- a/cutter2/ViewControllers/CAPARViewController.swift
+++ b/cutter2/ViewControllers/CAPARViewController.swift
@@ -67,7 +67,10 @@ class CAPARViewController: NSViewController {
         
         self.parentWindow = parent
         guard let sheet = self.view.window else { return }
-        parent.beginSheet(sheet, completionHandler: handler)
+        parent.beginSheet(sheet) { [weak self] response in
+            self?.removeTextObserver()
+            handler(response)
+        }
         
         let textHandler: @Sendable (Notification) -> Void = { [weak self] notification in
             
@@ -102,14 +105,19 @@ class CAPARViewController: NSViewController {
         guard let sheet = self.view.window else { return }
         parent.endSheet(sheet, returnCode: response)
         
-        do {
-            guard let observer = self.textObserver else { return }
-            let center = NotificationCenter.default
-            center.removeObserver(observer,
-                                  name: NSControl.textDidChangeNotification,
-                                  object: nil)
-            self.textObserver = nil
-        }
+        removeTextObserver()
+    }
+    
+    private func removeTextObserver() {
+        guard let observer = self.textObserver else { return }
+        NotificationCenter.default.removeObserver(observer,
+                                                  name: NSControl.textDidChangeNotification,
+                                                  object: nil)
+        self.textObserver = nil
+    }
+    
+    deinit {
+        removeTextObserver()
     }
     
     /* ============================================ */


### PR DESCRIPTION
This PR hardens save/export and observer cleanup paths in cutter2.

Changes:
- Guard `UTType(...)` conversions in the save panel.
- Replace custom export `preconditionFailure` paths with `throwError(.movieWriterFailed, ...)`.
- Ensure CAPAR text observers are removed from both sheet completion and `deinit`.
- Preserve undo history after SaveAs by reloading the existing mutator in place.

Verification:
- Xcode Build: SUCCEEDED
- Xcode Analyze: SUCCEEDED
