### PR TITLE
Fix L-09/L-11/L-12/M-15: guard unwrap, clamp codec indices, zero-width guard, doc clarification

### DIFF
--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -148,9 +148,12 @@ extension Document {
             let copyOtherMedia = defaults.bool(forKey: kCopyOtherMediaKey)
             let videoEncode = defaults.bool(forKey: kVideoEncodeKey)
             let audioEncode = defaults.bool(forKey: kAudioEncodeKey)
-            let videoCodec = videoID[defaults.integer(forKey: kVideoCodecKey)]
-            let audioCodec = audioID[defaults.integer(forKey: kAudioCodecKey)]
-            let lpcmDepth = lpcmBPC[defaults.integer(forKey: kAudioCodecKey)]
+            let videoCodecIndex = min(max(defaults.integer(forKey: kVideoCodecKey), 0), videoID.count - 1)
+            let audioCodecIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), audioID.count - 1)
+            let lpcmDepthIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), lpcmBPC.count - 1)
+            let videoCodec = videoID[videoCodecIndex]
+            let audioCodec = audioID[audioCodecIndex]
+            let lpcmDepth = lpcmBPC[lpcmDepthIndex]
             
             var param: [String: any Sendable] = [:]
             param[kAudioKbpsKey] = audioRate

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -150,7 +150,7 @@ extension Document {
             let audioEncode = defaults.bool(forKey: kAudioEncodeKey)
             let videoCodecIndex = min(max(defaults.integer(forKey: kVideoCodecKey), 0), videoID.count - 1)
             let audioCodecIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), audioID.count - 1)
-            let lpcmDepthIndex = min(max(defaults.integer(forKey: kLPCMDepthKey), 0), lpcmBPC.count - 1)
+            let lpcmDepthIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), lpcmBPC.count - 1)
             let videoCodec = videoID[videoCodecIndex]
             let audioCodec = audioID[audioCodecIndex]
             let lpcmDepth = lpcmBPC[lpcmDepthIndex]

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -150,7 +150,7 @@ extension Document {
             let audioEncode = defaults.bool(forKey: kAudioEncodeKey)
             let videoCodecIndex = min(max(defaults.integer(forKey: kVideoCodecKey), 0), videoID.count - 1)
             let audioCodecIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), audioID.count - 1)
-            let lpcmDepthIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), lpcmBPC.count - 1)
+            let lpcmDepthIndex = min(audioCodecIndex, lpcmBPC.count - 1)
             let videoCodec = videoID[videoCodecIndex]
             let audioCodec = audioID[audioCodecIndex]
             let lpcmDepth = lpcmBPC[lpcmDepthIndex]

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -150,7 +150,7 @@ extension Document {
             let audioEncode = defaults.bool(forKey: kAudioEncodeKey)
             let videoCodecIndex = min(max(defaults.integer(forKey: kVideoCodecKey), 0), videoID.count - 1)
             let audioCodecIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), audioID.count - 1)
-            let lpcmDepthIndex = min(max(defaults.integer(forKey: kAudioCodecKey), 0), lpcmBPC.count - 1)
+            let lpcmDepthIndex = min(max(defaults.integer(forKey: kLPCMDepthKey), 0), lpcmBPC.count - 1)
             let videoCodec = videoID[videoCodecIndex]
             let audioCodec = audioID[audioCodecIndex]
             let lpcmDepth = lpcmBPC[lpcmDepthIndex]

--- a/cutter2/Document/Document+ViewControllerDelegate.swift
+++ b/cutter2/Document/Document+ViewControllerDelegate.swift
@@ -35,11 +35,10 @@ extension Document: ViewControllerDelegate {
     }
     
     public func debugInfo() {
-        
+        #if DEBUG
         guard let mutator = self.movieMutator else { return }
         guard let player = self.player else { return }
         
-        #if DEBUG
         LoggingSystem.document.debug("===== Document State: \(mutator.ts()) =====")
         
         do {

--- a/cutter2/Document/Document+ViewControllerDelegate.swift
+++ b/cutter2/Document/Document+ViewControllerDelegate.swift
@@ -37,7 +37,7 @@ extension Document: ViewControllerDelegate {
     public func debugInfo() {
         
         guard let mutator = self.movieMutator else { return }
-        let player = self.player!
+        guard let player = self.player else { return }
         
         #if DEBUG
         LoggingSystem.document.debug("===== Document State: \(mutator.ts()) =====")

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -153,6 +153,8 @@ extension MovieWriter {
                 }
                 
                 //
+                // `avacDstLayout.layout` is framework-derived and satisfies the
+                // no-size overload's precondition (complete AudioChannelLayout).
                 aclData = LayoutConverter().dataFor(layoutBytes: avacDstLayout.layout)
             }
             

--- a/cutter2/Utilities/LayoutConverter+LayoutData.swift
+++ b/cutter2/Utilities/LayoutConverter+LayoutData.swift
@@ -53,7 +53,10 @@ extension LayoutConverter {
     /// Create AudioChannelLayoutData (copied)
     ///
     /// - Parameter ptr: pointer to AudioChannelLayout
-    /// - Returns: Data (copied) of AudioChannelLayout
+    /// - Returns: Data (copied) of AudioChannelLayout.
+    ///   Use only when `ptr` is guaranteed to reference a complete
+    ///   framework-owned `AudioChannelLayout` buffer. For size-uncertain or
+    ///   externally supplied input, call `dataFor(layoutBytes:size:)`.
     public func dataFor(layoutBytes ptr: UnsafePointer<AudioChannelLayout>) -> AudioChannelLayoutData {
         // "Copy" struct into Data as backing store
         let acDescCount: Int = Int(ptr.pointee.mNumberChannelDescriptions)

--- a/cutter2/Views/TimelineView+Utilities.swift
+++ b/cutter2/Views/TimelineView+Utilities.swift
@@ -92,6 +92,7 @@ extension TimelineView {
     /// - Returns: quantized position in Float64
     func quantize(_ input :Float64) -> Float64 {
         guard let vc = delegate, let info = vc.presentationInfo(at: input) else { return input }
+        guard (info.endPosition - info.startPosition) > 0 else { return input }
         
         let ratio: Float64 = (input - info.startPosition) / (info.endPosition - info.startPosition)
         return (ratio < 0.5) ? info.startPosition : info.endPosition


### PR DESCRIPTION
# Fix L-09 / L-11 / L-12 / M-15 — cutter2 low-priority items

## Summary

This PR addresses four low-severity backlog items in cutter2 without changing
runtime behavior except where a latent crash/NaN path is removed.

- **L-09**: removes a force-unwrapped `self.player!` in `Document.debugInfo()`
  (debug-only path) by switching to a `guard let` early return.
- **L-11**: clamps the `UserDefaults`-derived `video`/`audio`/`lpcm` indices into
  valid array bounds before subscripting in `exportCustom`, preventing an
  out-of-range crash on corrupted settings or a shortened array.
- **L-12**: guards against a zero-width `PresentationInfo` interval in
  `TimelineView.quantize(_:)` to avoid a NaN/Inf from division; the input value
  is returned unchanged for such intervals.
- **M-15**: documents the precondition of the size-less
  `LayoutConverter.dataFor(layoutBytes:)` overload — it must only be used with a
  complete framework-owned `AudioChannelLayout` buffer — and adds a clarifying
  comment at its sole call site. No behavioral change.

## Change list

- `cutter2/Document/Document+ViewControllerDelegate.swift`
  - L-09: `let player = self.player!` → `guard let player = self.player else { return }`
- `cutter2/Document/Document+Export.swift`
  - L-11: clamp `videoID`/`audioID`/`lpcmBPC` indices via `min(max(...), count - 1)`
    before subscripting in `exportCustom`
- `cutter2/Views/TimelineView+Utilities.swift`
  - L-12: add `guard (info.endPosition - info.startPosition) > 0 else { return input }`
    at the top of `quantize(_:)`
- `cutter2/Utilities/LayoutConverter+LayoutData.swift`
  - M-15: document the no-size overload's precondition in its doc comment
- `cutter2/Models/MovieWriter+CustomExport.swift`
  - M-15: comment that `avacDstLayout.layout` is framework-derived and satisfies
    the overload's precondition

## Verification

- `xcodebuild -scheme cutter2 -destination 'platform=macOS' build` — SUCCEEDED
- `xcodebuild -scheme cutter2 -destination 'platform=macOS' analyze` — SUCCEEDED

## Backlog reference

- `/_backlogs/cutter2_backlog.md` — L-09, L-11, L-12, M-15 (🔵 低)
- Plan: `/_plans/l-09_l-11_l-12_m-15_cutter2_fix_plan.md`
