### PR TITLE
test(T-01): add AsyncBridge.perform timeout / error / main thread tests

### DIFF
--- a/cutter2Tests/AsyncBridgeTests.swift
+++ b/cutter2Tests/AsyncBridgeTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import Foundation
+@testable import cutter2
+
+final class AsyncBridgeTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private enum TestError: Error { case expected }
+
+    func testPerformCompletesWithValue() async {
+        let task = Task.detached {
+            try AsyncBridge.perform(timeout: 1.0, allowMainThread: false) { @Sendable in
+                42
+            }
+        }
+        do {
+            let result = try await task.value
+            XCTAssertEqual(result, 42)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testPerformPropagatesThrow() async {
+        var caught = false
+        let task = Task.detached {
+            try AsyncBridge.perform(timeout: 1.0, allowMainThread: false) { @Sendable in
+                throw TestError.expected
+            }
+        }
+        do {
+            _ = try await task.value
+        } catch TestError.expected {
+            caught = true
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertTrue(caught)
+    }
+
+    func testPerformTimeout() async {
+        var caughtTimeout = false
+        let task = Task.detached {
+            try AsyncBridge.perform(timeout: 0.01, allowMainThread: false) { @Sendable in
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                return 0
+            }
+        }
+        do {
+            _ = try await task.value
+        } catch PerformAsyncError.timeout(_) {
+            caughtTimeout = true
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertTrue(caughtTimeout)
+    }
+
+    func testPerformAllowMainThread() {
+        do {
+            let value = try AsyncBridge.perform(timeout: nil, allowMainThread: true) { @Sendable in
+                "ok"
+            }
+            XCTAssertEqual(value, "ok")
+        } catch {
+            XCTFail("unexpected throw: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Adds 4 unit tests for `AsyncBridge` (122 lines, zero existing test coverage).

## Tests

| Test | Scenario |
|---|---|
| `testPerformCompletesWithValue` | async block returns `42` → `42` |
| `testPerformPropagatesThrow` | async block throws → error propagates |
| `testPerformTimeout` | `timeout: 0.01` + `Task.sleep(1s)` → `.timeout` |
| `testPerformAllowMainThread` | `allowMainThread: true` from main thread → success |

## Verification

- `xcodebuild -only-testing:cutter2Tests/AsyncBridgeTests test` → **SUCCEEDED** (4/4)
- `xcodebuild clean build` → no warnings
- `xcodebuild build-for-testing` → no warnings
- Zero production diff

## Plan

`/_plans/T-01_async_bridge_tests_plan.md`