### PR TITLE
Fix M-18/M-19/S-13: Document @unchecked Sendable rationale, allowMainThread safety, and AVFoundation DispatchQueue usage

### DIFF
--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -105,6 +105,7 @@ extension Document {
         // through AsyncBridge.
         let preparation: OpenPreparation
         do {
+            // allowMainThread: true — canConcurrentlyReadDocuments == true, so AppKit calls from a background queue. Safe.
             preparation = try AsyncBridge.perform(timeout: 30, allowMainThread: true) { @Sendable in
                 let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
                 let modificationDate = attrs[.modificationDate] as? Date

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -105,7 +105,9 @@ extension Document {
         // through AsyncBridge.
         let preparation: OpenPreparation
         do {
-            // allowMainThread: true — canConcurrentlyReadDocuments == true, so AppKit calls from a background queue. Safe.
+            // allowMainThread: true — the bridged async block performs only file I/O
+            // and AVMovie header parsing, deliberately staying MainActor-free so no
+            // deadlock can occur even if NSDocument invokes read() on the main thread.
             preparation = try AsyncBridge.perform(timeout: 30, allowMainThread: true) { @Sendable in
                 let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
                 let modificationDate = attrs[.modificationDate] as? Date

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -655,9 +655,10 @@ extension MovieWriter {
     }
     
     /// `@unchecked Sendable` rationale:
-    /// `cancelParams` is only accessed on `customQueue` for sequential processing.
-    /// The `channels` array is read only from `customQueue.async` blocks inside `cancelCustomMovie()`.
-    /// No data races are possible.
+    /// `cancelParams` is created on the `MovieWriter` actor (in `cancelCustomMovie`)
+    /// and then captured by a `@Sendable` closure dispatched to `customQueue`.
+    /// The `channels` array is read only from `customQueue.async` blocks, so no
+    /// data races occur across the actor-to-queue handoff.
     private struct cancelParams: @unchecked Sendable {
         let channels: [SampleBufferChannel]
     }
@@ -691,9 +692,10 @@ extension MovieWriter {
     }
     
     /// `@unchecked Sendable` rationale:
-    /// `didReadParams` is confined to sequential processing on `customQueue`.
-    /// `channel` and `buffer` are processed serially on `customQueue` and
-    /// accessed only from the `didRead` callback. No data races.
+    /// `didReadParams` is created in the `nonisolated` `didRead` delegate callback
+    /// and then captured by a `@Sendable` closure in a `Task`. The struct is
+    /// consumed only from within that `Task` (via `didReadCore`), so no data races
+    /// occur across the nonisolated-to-async handoff.
     private struct didReadParams: @unchecked Sendable {
         let channel: SampleBufferChannel
         let buffer: CMSampleBuffer

--- a/cutter2/Models/MovieWriter+CustomExport.swift
+++ b/cutter2/Models/MovieWriter+CustomExport.swift
@@ -654,6 +654,10 @@ extension MovieWriter {
         }
     }
     
+    /// `@unchecked Sendable` rationale:
+    /// `cancelParams` is only accessed on `customQueue` for sequential processing.
+    /// The `channels` array is read only from `customQueue.async` blocks inside `cancelCustomMovie()`.
+    /// No data races are possible.
     private struct cancelParams: @unchecked Sendable {
         let channels: [SampleBufferChannel]
     }
@@ -686,6 +690,10 @@ extension MovieWriter {
         //}
     }
     
+    /// `@unchecked Sendable` rationale:
+    /// `didReadParams` is confined to sequential processing on `customQueue`.
+    /// `channel` and `buffer` are processed serially on `customQueue` and
+    /// accessed only from the `didRead` callback. No data races.
     private struct didReadParams: @unchecked Sendable {
         let channel: SampleBufferChannel
         let buffer: CMSampleBuffer

--- a/cutter2/Models/MovieWriter.swift
+++ b/cutter2/Models/MovieWriter.swift
@@ -108,6 +108,12 @@ extension Notification.Name {
 // MARK: -
 /* ============================================ */
 
+/// `@unchecked Sendable` rationale:
+/// `MovieWriterParams` is created by `prepareMovieWriterParams()` and
+/// immediately moved into the `MovieWriter` actor (effectively move-only).
+/// `progressContinuation` and `unblockUserInteraction` are accessed only
+/// within the `MovieWriter` actor. `movie` (`AVMutableMovie`) is mutated
+/// only under actor isolation.
 struct MovieWriterParams: @unchecked Sendable {
     let movie: AVMutableMovie
     let unblockUserInteraction: (@Sendable () -> Void)?

--- a/cutter2/Models/SampleBufferChannel.swift
+++ b/cutter2/Models/SampleBufferChannel.swift
@@ -14,10 +14,13 @@ protocol SampleBufferChannelDelegate: AnyObject {
 }
 
 /// `@unchecked Sendable` rationale:
-/// `SampleBufferChannel` had data races fixed in S-12 (PR #53) via `UnfairLockBox`.
-/// `finished` / `completionHandler` are accessed under `UnfairLockBox` protection.
-/// `delegate` is held as a `weak` reference, and `queue` is a `DispatchQueue` (thread-safe).
-/// `@unchecked` is intentional; internal synchronization makes it safe.
+/// Thread safety is achieved by confining all mutation of `finished` and
+/// `completionHandler` to the serial `queue`. `start()` sets `delegate` and
+/// `completionHandler` before the `requestMediaDataWhenReady` callback fires on
+/// `queue`, so there is no race between `start()` and the callback. `cancel()`
+/// also dispatches to `queue` before touching `finished`. `delegate` is held
+/// as a `weak` reference. `@unchecked` is intentional; the serial queue
+/// guarantees sequential access.
 class SampleBufferChannel: @unchecked Sendable {
     
     init(readerOutput: AVAssetReaderOutput, writerInput: AVAssetWriterInput, trackID: CMPersistentTrackID) {

--- a/cutter2/Models/SampleBufferChannel.swift
+++ b/cutter2/Models/SampleBufferChannel.swift
@@ -13,6 +13,11 @@ protocol SampleBufferChannelDelegate: AnyObject {
     func didRead(from channel: SampleBufferChannel, buffer: CMSampleBuffer)
 }
 
+/// `@unchecked Sendable` rationale:
+/// `SampleBufferChannel` had data races fixed in S-12 (PR #53) via `UnfairLockBox`.
+/// `finished` / `completionHandler` are accessed under `UnfairLockBox` protection.
+/// `delegate` is held as a `weak` reference, and `queue` is a `DispatchQueue` (thread-safe).
+/// `@unchecked` is intentional; internal synchronization makes it safe.
 class SampleBufferChannel: @unchecked Sendable {
     
     init(readerOutput: AVAssetReaderOutput, writerInput: AVAssetWriterInput, trackID: CMPersistentTrackID) {

--- a/docs/ConcurrencyGuidelines.md
+++ b/docs/ConcurrencyGuidelines.md
@@ -141,10 +141,20 @@ nonisolated func performAsync<T: Sendable>(
 
 **Allowed ONLY for:**
 - `SampleBufferChannel` dispatch queue in `MovieWriter+CustomExport.swift` (AudioToolbox interop)
+- AVFoundation `requestMediaDataWhenReady(on:queue:)` API (AVFoundation interop)
 - `OperationQueue.main` for `NotificationCenter` (AppKit requirement)
 - `Timer.scheduledTimer` (Foundation API)
 
 **Migration target:** Replace with `Task` / `AsyncBridge` / `ActorUtilities` where possible.
+
+#### AVFoundation `requestMediaDataWhenReady` DispatchQueue Usage
+
+The `requestMediaDataWhenReady(on:queue:)` API in AVFoundation asynchronously notifies on the specified `DispatchQueue` when media data is ready for writing. This is an official AVFoundation API that requires a `DispatchQueue` parameter.
+
+- **Usage location:** `cutter2/Models/SampleBufferChannel.swift:60` (queue created at `MovieWriter+CustomExport.swift:539`)
+- **Reason:** AVFoundation API contract requires `DispatchQueue` — cannot be replaced with `Task` / `async`.
+- **Safety:** `requestMediaDataWhenReady` processes sequentially on the queue, so no data races occur. Queue cleanup happens at `stopRequestingMediaData` call.
+- **Note:** This API must be called outside `actor` isolation. When called from within the `MovieWriter` actor, use `DispatchQueue.global(qos:)` and pass data back to the actor via `@Sendable` closure.
 
 ---
 

--- a/docs/ConcurrencyGuidelines.md
+++ b/docs/ConcurrencyGuidelines.md
@@ -141,7 +141,7 @@ nonisolated func performAsync<T: Sendable>(
 
 **Allowed ONLY for:**
 - `SampleBufferChannel` dispatch queue in `MovieWriter+CustomExport.swift` (AudioToolbox interop)
-- AVFoundation `requestMediaDataWhenReady(on:queue:)` API (AVFoundation interop)
+- AVFoundation `requestMediaDataWhenReady(on:using:)` API (AVFoundation interop)
 - `OperationQueue.main` for `NotificationCenter` (AppKit requirement)
 - `Timer.scheduledTimer` (Foundation API)
 
@@ -149,7 +149,7 @@ nonisolated func performAsync<T: Sendable>(
 
 #### AVFoundation `requestMediaDataWhenReady` DispatchQueue Usage
 
-The `requestMediaDataWhenReady(on:queue:)` API in AVFoundation asynchronously notifies on the specified `DispatchQueue` when media data is ready for writing. This is an official AVFoundation API that requires a `DispatchQueue` parameter.
+The `requestMediaDataWhenReady(on:using:)` API in AVFoundation asynchronously notifies on the specified `DispatchQueue` when media data is ready for writing. This is an official AVFoundation API that requires a `DispatchQueue` parameter.
 
 - **Usage location:** `cutter2/Models/SampleBufferChannel.swift:60` (queue created at `MovieWriter+CustomExport.swift:539`)
 - **Reason:** AVFoundation API contract requires `DispatchQueue` — cannot be replaced with `Task` / `async`.


### PR DESCRIPTION
## Summary

This PR addresses three backlog items (M-18, M-19, S-13) related to documentation and code comment improvements:

### M-18: Document @unchecked Sendable rationale for 4 types
Add doc comments to 4 `@unchecked Sendable` types explaining their thread-safety rationale:
- `cancelParams` (MovieWriter+CustomExport.swift:657)
- `didReadParams` (MovieWriter+CustomExport.swift:689)
- `MovieWriterParams` (MovieWriter.swift:111)
- `SampleBufferChannel` (SampleBufferChannel.swift:16)

### M-19: Document allowMainThread: true safety in Document+FileIO.swift
Add a safety comment for `allowMainThread: true` in `Document+FileIO.swift:108`.

### S-13: Add AVFoundation DispatchQueue usage section to ConcurrencyGuidelines.md §7
Add AVFoundation `requestMediaDataWhenReady(on:queue:)` to the allowed DispatchQueue usage list in `ConcurrencyGuidelines.md` §7, with a detailed subsection explaining the rationale, safety, and usage notes.

## Verification

- Xcode Build / Analyze: SUCCEEDED (no logic changes, comments only)
- Existing tests: unaffected (no code logic changes)
- `git diff --stat`: 5 files changed, 30 insertions(+)

## Plan

See `/_plans/M-18_unchecked_sendable_doc_plan.md`, `/_plans/M-19_allow_main_thread_doc_plan.md`, `/_plans/S-13_avfoundation_dispatchqueue_doc_plan.md`