### PR TITLE
Fix M-20: document CF typealias as! safety in Inspector and Transform

### DIFF
--- a/cutter2/Models/MovieMutator+Inspector.swift
+++ b/cutter2/Models/MovieMutator+Inspector.swift
@@ -110,8 +110,10 @@ extension MovieMutatorBase {
             let trackID: Int = Int(track.trackID)
             let reference: Bool = !(track.isSelfContained)
             // CMVideoFormatDescription is a CF typealias of CMFormatDescription.
-            // as! is safe: the compiler guarantees the cast always succeeds.
-            // as? is rejected by Swift 6 strict concurrency ("will always succeed").
+            // as! is safe: the Swift compiler guarantees the cast always succeeds
+            // ("conditional downcast will always succeed"). as? is rejected by the
+            // compiler for this reason. If the SDK ever changes the type hierarchy,
+            // the force-cast will trap loudly rather than silently misbehave.
             for desc in track.formatDescriptions as! [CMVideoFormatDescription] {
                 var name: String = ""
                 do {
@@ -170,8 +172,10 @@ extension MovieMutatorBase {
             let trackID: Int = Int(track.trackID)
             let reference: Bool = !(track.isSelfContained)
             // CMAudioFormatDescription is a CF typealias of CMFormatDescription.
-            // as! is safe: the compiler guarantees the cast always succeeds.
-            // as? is rejected by Swift 6 strict concurrency ("will always succeed").
+            // as! is safe: the Swift compiler guarantees the cast always succeeds
+            // ("conditional downcast will always succeed"). as? is rejected by the
+            // compiler for this reason. If the SDK ever changes the type hierarchy,
+            // the force-cast will trap loudly rather than silently misbehave.
             for desc in track.formatDescriptions as! [CMAudioFormatDescription] {
                 var rateString: String = ""
                 do {

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -82,9 +82,11 @@ extension MovieMutator {
         
         let formats: [Any] = (vTracks[0]).formatDescriptions
         guard !formats.isEmpty else { NSSound.beep(); return nil }
-        // formats[0] is CMFormatDescription (CF type). as! is safe: the compiler
-        // guarantees the cast always succeeds. as? is rejected by Swift 6 strict
-        // concurrency ("will always succeed"). Index 0 is safe after isEmpty guard.
+        // formats[0] is CMFormatDescription (CF type). as! is safe: the Swift
+        // compiler guarantees the cast always succeeds ("conditional downcast
+        // will always succeed"). as? is rejected by the compiler for this reason.
+        // If the SDK ever changes the type hierarchy, the force-cast will trap
+        // loudly rather than silently misbehave. Index 0 is safe after isEmpty guard.
         let desc = formats[0] as! CMFormatDescription
         
         dict[dimensionsKey] = CMVideoFormatDescriptionGetPresentationDimensions(desc,
@@ -133,9 +135,11 @@ extension MovieMutator {
         
         let vTracks: [AVMutableMovieTrack] = movie.tracks(withMediaType: .video)
         for track in vTracks {
-            // CMFormatDescription is a CF type. as! is safe: the compiler guarantees
-            // the cast always succeeds. as? is rejected by Swift 6 strict concurrency
-            // ("will always succeed").
+            // CMFormatDescription is a CF type. as! is safe: the Swift compiler
+            // guarantees the cast always succeeds ("conditional downcast will
+            // always succeed"). as? is rejected by the compiler for this reason.
+            // If the SDK ever changes the type hierarchy, the force-cast will trap
+            // loudly rather than silently misbehave.
             let formats = track.formatDescriptions as! [CMFormatDescription]
             
             // Verify if track.encodedDimension is equal to target dimensions


### PR DESCRIPTION
## Summary

Document the safety of 4 `as!` CF typealias casts in `MovieMutator+Inspector.swift` and `MovieMutator+Transform.swift`.

## Problem

The backlog item M-20 requested replacing `as!` force-casts with `as?` + `guard let` for 4 CF typealias casts (`CMVideoFormatDescription` / `CMAudioFormatDescription` / `CMFormatDescription`). However, Swift 6 strict concurrency (`SWIFT_STRICT_CONCURRENCY = complete`) rejects `as?` for CF typealias casts with the error "conditional downcast to CoreFoundation type will always succeed" — the compiler knows `formatDescriptions` returns `[CMFormatDescription]` (bridged as `[Any]`), so casting to a CF typealias is always safe and `as?` is flagged as unnecessary.

## Fix

Consistent with L-01 (PR #38) which already made the same decision for 10 other CF typealias casts, `as!` is retained. Each cast site now has a 3-line comment explaining:
1. Why `as!` is safe (compiler guarantees the cast always succeeds)
2. Why `as?` is rejected by Swift 6 strict concurrency ("will always succeed")
3. Future SDK change resilience (if the SDK changes the type hierarchy, the compiler will stop guaranteeing safety and `as!` will fail with `EXC_BAD_INSTRUCTION` rather than silent data corruption)

## Files Changed

- `cutter2/Models/MovieMutator+Inspector.swift:112` — `track.formatDescriptions as! [CMVideoFormatDescription]`
- `cutter2/Models/MovieMutator+Inspector.swift:169` — `track.formatDescriptions as! [CMAudioFormatDescription]`
- `cutter2/Models/MovieMutator+Transform.swift:85` — `formats[0] as! CMFormatDescription`
- `cutter2/Models/MovieMutator+Transform.swift:133` — `track.formatDescriptions as! [CMFormatDescription]`

## Verification

- Xcode clean build: SUCCEEDED
- Xcode analyze: SUCCEEDED
- XCTest (148 tests): all passed
- Plan: `/_plans/M-20_as_force_cast_guard_plan.md` (v2)
