### PR TITLE
Fix L-15/L-16: modernize KVO to NSKeyValueObservation and add PerformanceMetrics instrumentation

### DIFF
--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -119,16 +119,7 @@ extension Document {
             progressTask.cancel()
         }
         
-        // Select metric name based on operationName to avoid mixing write/export metrics
-        let metricName: String = switch operationName {
-        case "write": PerformanceMetrics.Operation.fileSave
-        case "custom export": PerformanceMetrics.Operation.customExport
-        default: PerformanceMetrics.Operation.fileExport
-        }
-        
-        return try await PerformanceMetrics.shared.measureAsync(metricName) {
-            try await operation(mutator)
-        }
+        return try await operation(mutator)
     }
     
     internal func export(to url: URL, ofType typeName: String, preset: String) async throws {

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -119,7 +119,14 @@ extension Document {
             progressTask.cancel()
         }
         
-        return try await PerformanceMetrics.shared.measureAsync(PerformanceMetrics.Operation.fileExport) {
+        // Select metric name based on operationName to avoid mixing write/export metrics
+        let metricName: String = switch operationName {
+        case "write": PerformanceMetrics.Operation.fileSave
+        case "custom export": PerformanceMetrics.Operation.customExport
+        default: PerformanceMetrics.Operation.fileExport
+        }
+        
+        return try await PerformanceMetrics.shared.measureAsync(metricName) {
             try await operation(mutator)
         }
     }

--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -119,7 +119,9 @@ extension Document {
             progressTask.cancel()
         }
         
-        return try await operation(mutator)
+        return try await PerformanceMetrics.shared.measureAsync(PerformanceMetrics.Operation.fileExport) {
+            try await operation(mutator)
+        }
     }
     
     internal func export(to url: URL, ofType typeName: String, preset: String) async throws {

--- a/cutter2/Models/MovieMutator+Export.swift
+++ b/cutter2/Models/MovieMutator+Export.swift
@@ -50,20 +50,26 @@ extension MovieMutator {
     }
     
     public func exportMovie(to url: URL, fileType type: AVFileType, presetName preset: String?) async throws {
-        try await withMovieWriter { movieWriter in
-            try await movieWriter.exportMovie(to: url, fileType: type, presetName: preset)
+        try await PerformanceMetrics.shared.measureAsync(PerformanceMetrics.Operation.videoExport) {
+            try await withMovieWriter { movieWriter in
+                try await movieWriter.exportMovie(to: url, fileType: type, presetName: preset)
+            }
         }
     }
     
     public func exportCustomMovie(to url: URL, fileType type: AVFileType, settings param: [String: any Sendable]) async throws {
-        try await withMovieWriter { movieWriter in
-            try await movieWriter.exportCustomMovie(to: url, fileType: type, settings: param)
+        try await PerformanceMetrics.shared.measureAsync(PerformanceMetrics.Operation.customExport) {
+            try await withMovieWriter { movieWriter in
+                try await movieWriter.exportCustomMovie(to: url, fileType: type, settings: param)
+            }
         }
     }
     
     public func writeMovie(to url: URL, fileType type: AVFileType, copySampleData selfContained: Bool) async throws {
-        try await withMovieWriter { movieWriter in
-            try await movieWriter.writeMovie(to: url, fileType: type, copySampleData: selfContained)
+        try await PerformanceMetrics.shared.measureAsync(PerformanceMetrics.Operation.fileSave) {
+            try await withMovieWriter { movieWriter in
+                try await movieWriter.writeMovie(to: url, fileType: type, copySampleData: selfContained)
+            }
         }
     }
     

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -10,9 +10,11 @@ import Cocoa
 import AVFoundation
 
 extension UserDefaults {
+    private static let useStepModeKey = "useStepMode"
+    
     @objc dynamic var useStepMode: Bool {
-        get { bool(forKey: "useStepMode") }
-        set { set(newValue, forKey: "useStepMode") }
+        get { bool(forKey: Self.useStepModeKey) }
+        set { set(newValue, forKey: Self.useStepModeKey) }
     }
 }
 
@@ -29,7 +31,7 @@ extension ViewController {
     internal func addUserDefaultObserver() {
         stepModeObservation = UserDefaults.standard.observe(\.useStepMode, options: [.initial, .new]) { [weak self] defaults, change in
             guard let self else { return }
-            guard let newValue = change.newValue, let newBool = newValue as? Bool else { return }
+            guard let newBool = change.newValue else { return }
             
             // Inversion logic preserved: useStepMode=true → mimicJKLcombination=false
             let inverted = !newBool

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -9,6 +9,13 @@
 import Cocoa
 import AVFoundation
 
+extension UserDefaults {
+    @objc dynamic var useStepMode: Bool {
+        get { bool(forKey: "useStepMode") }
+        set { set(newValue, forKey: "useStepMode") }
+    }
+}
+
 /* ============================================ */
 // MARK: - Observer utilities
 /* ============================================ */
@@ -20,35 +27,21 @@ extension ViewController {
     /* ============================================ */
     
     internal func addUserDefaultObserver() {
-        let defaults = UserDefaults.standard
-        defaults.addObserver(self,
-                             forKeyPath: keyPathStepMode,
-                             options: [.initial, .old,.new],
-                             context: nil)
+        stepModeObservation = UserDefaults.standard.observe(\.useStepMode, options: [.initial, .new]) { [weak self] defaults, change in
+            guard let self else { return }
+            guard let newValue = change.newValue, let newBool = newValue as? Bool else { return }
+            
+            // ★ 反転ロジックを維持: useStepMode=true → mimicJKLcombination=false
+            if self.mimicJKLcombination != newBool {
+                self.mimicJKLcombination = newBool
+                self.applyMode()
+            }
+        }
     }
     
     internal func removeUserDefaultsObserver() {
-        let defaults = UserDefaults.standard
-        defaults.removeObserver(self,
-                                forKeyPath: keyPathStepMode)
-    }
-    
-    override nonisolated func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey:Any]?,
-                                           context: UnsafeMutableRawPointer?) {
-        guard let keyPath = keyPath else { return }
-        guard let change: [NSKeyValueChangeKey:Any] = change else { return }
-        guard let newAny = change[.newKey] else { return }
-        
-        if keyPath == keyPathStepMode, let newNumber = newAny as? NSNumber {
-            let new: Bool = !newNumber.boolValue
-            ActorUtilities.performSyncOnMainActor {
-                if mimicJKLcombination != new {
-                    mimicJKLcombination = new
-                    
-                    applyMode()
-                }
-            }
-        }
+        stepModeObservation?.invalidate()
+        stepModeObservation = nil
     }
     
     /* ============================================ */

--- a/cutter2/ViewControllers/ViewController+Observer.swift
+++ b/cutter2/ViewControllers/ViewController+Observer.swift
@@ -31,10 +31,13 @@ extension ViewController {
             guard let self else { return }
             guard let newValue = change.newValue, let newBool = newValue as? Bool else { return }
             
-            // ★ 反転ロジックを維持: useStepMode=true → mimicJKLcombination=false
-            if self.mimicJKLcombination != newBool {
-                self.mimicJKLcombination = newBool
-                self.applyMode()
+            // Inversion logic preserved: useStepMode=true → mimicJKLcombination=false
+            let inverted = !newBool
+            ActorUtilities.performSyncOnMainActor {
+                if self.mimicJKLcombination != inverted {
+                    self.mimicJKLcombination = inverted
+                    self.applyMode()
+                }
             }
         }
     }

--- a/cutter2/ViewControllers/ViewController.swift
+++ b/cutter2/ViewControllers/ViewController.swift
@@ -62,6 +62,7 @@ class ViewController: NSViewController, TimelineUpdateDelegate {
     // Notification Observer
     internal var resizeObserver: NSObjectProtocol? = nil
     internal var updateObserver: NSObjectProtocol? = nil
+    internal var stepModeObservation: NSKeyValueObservation? = nil
     
     /* ============================================ */
     // MARK: - public properties

--- a/cutter2/ViewControllers/ViewController.swift
+++ b/cutter2/ViewControllers/ViewController.swift
@@ -50,9 +50,6 @@ class ViewController: NSViewController, TimelineUpdateDelegate {
     // MARK: - private properties/constants
     /* ============================================ */
     
-    // Observer key
-    internal let keyPathStepMode: String = "useStepMode" // "values.useStepMode" is NG
-    
     // To mimic legacy QT7PlayerPro JKL key tracking
     internal var keyDownJ: Bool = false
     internal var keyDownK: Bool = false


### PR DESCRIPTION
## Summary

This PR addresses two backlog items from `cutter2_backlog.md`:

- **L-15**: Modernize legacy `@objc` KVO pattern to `NSKeyValueObservation`
- **L-16**: Add `PerformanceMetrics` instrumentation to export/write operation wrappers

## Changes

### L-15: KVO Modernization

**Files:**
- `cutter2/ViewControllers/ViewController+Observer.swift`
- `cutter2/ViewControllers/ViewController.swift`

**Changes:**
- Replace legacy `addObserver(forKeyPath:)` / `removeObserver(forKeyPath:)` with closure-based `observe(\.useStepMode, ...)`
- Remove `observeValue(forKeyPath:...)` override (no longer needed)
- Add `@objc dynamic var useStepMode` extension on `UserDefaults` for type-safe key path
- Move `stepModeObservation` property to `ViewController.swift` (stored properties not allowed in extensions)
- Maintain inversion logic: `useStepMode=true → mimicJKLcombination=false`

### L-16: PerformanceMetrics Instrumentation

**Files:**
- `cutter2/Models/MovieMutator+Export.swift`

**Changes:**
- Wrap `withMovieWriter` operations with:
  - `Operation.videoExport` for `exportMovie`
  - `Operation.customExport` for `exportCustomMovie`
  - `Operation.fileSave` for `writeMovie`

**Note:** `withBusyProgress` in `Document+Export.swift` is NOT instrumented to avoid double-counting. The underlying `withMovieWriter` wrappers already instrument the same operations. `withBusyProgress` is a UI-layer wrapper (busy sheet display) and should not record separate performance samples for the same operation.

Leverages S-09 (`nonisolated` `measureAsync`) for zero actor hop overhead.

## Verification

- **Build**: SUCCEEDED (no errors or warnings)
- **Analyze**: SUCCEEDED
- **Test**: SUCCEEDED (all tests pass)
- **Grep verification**:
  - `observeValue(forKeyPath:...)` removed: 0 matches
  - `addObserver(forKeyPath:)` removed: 0 matches
  - `observe(\.useStepMode` added: 1 match
  - `@objc dynamic var useStepMode` added: 1 match
  - `PerformanceMetrics.Operation.videoExport` in `MovieMutator+Export.swift`: 1 match
  - `PerformanceMetrics.Operation.customExport` in `MovieMutator+Export.swift`: 1 match
  - `PerformanceMetrics.Operation.fileSave` in `MovieMutator+Export.swift`: 1 match
  - Total `measureAsync` calls: 3 matches (only in `MovieMutator+Export.swift`)

## Related Backlog

- `cutter2_backlog.md` L-15 (🔵 低 — コードスメル・既知の制限)
- `cutter2_backlog.md` L-16 (🔵 低 — コードスメル・既知の制限)

## Plan Files

- `/_plans/L-15_modernize_kvo_plan.md` (v3)
- `/_plans/L-16_performance_metrics_instrumentation_plan.md` (v3)
