### PR TITLE
Fix H-09: replace preconditionFailure/precondition with guard in 20 user-reachable code paths

### DIFF
--- a/cutter2/Document/Document+Export.swift
+++ b/cutter2/Document/Document+Export.swift
@@ -26,13 +26,14 @@ extension Document {
         let storyboard: NSStoryboard = NSStoryboard(name: "Main", bundle: nil)
         let sid: NSStoryboard.SceneIdentifier = "TranscodeSheet Controller"
         guard let transcodeWC = storyboard.instantiateController(withIdentifier: sid) as? NSWindowController else {
-            preconditionFailure("Failed to instantiate TranscodeSheet Controller")
+            NSSound.beep()
+            return
         }
         // transcodeWC.loadWindow()
         
         // Prepare Transcode ViewController
-        guard let contVC = transcodeWC.contentViewController else { preconditionFailure("Unexpected nil contentViewController detected.") }
-        guard let transcodeVC = contVC as? TranscodeViewController else { preconditionFailure("Unexpected nil TranscodeViewController detected.") }
+        guard let contVC = transcodeWC.contentViewController else { NSSound.beep(); return }
+        guard let transcodeVC = contVC as? TranscodeViewController else { NSSound.beep(); return }
         
         // Show Transcode Sheet
         transcodeVC.beginSheetModal(for: self.window!) { @Sendable @MainActor [weak self] (response) in // @escaping

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -244,14 +244,12 @@ extension Document {
                 let fileType: AVFileType = AVFileType.init(rawValue: typeName)
                 guard fileType == .mov else { return }
                 
-                guard let accessoryVC = self.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
+                guard let accessoryVC = self.accessoryVC else { return }
                 let saveAsRefMov: Bool = (accessoryVC.selfContained == false)
                 guard saveAsRefMov else { return }
                 
                 // SaveAs reference movie - Need to keep readonly access to original
-                guard let app = NSApp.delegate as? AppDelegate else {
-                    preconditionFailure("NSApp.delegate is not AppDelegate")
-                }
+                guard let app = NSApp.delegate as? AppDelegate else { return }
                 app.addBookmark(for: srcURL)
             }
         }

--- a/cutter2/Document/Document+SavePanel.swift
+++ b/cutter2/Document/Document+SavePanel.swift
@@ -30,13 +30,14 @@ extension Document {
             let storyboard: NSStoryboard = NSStoryboard(name: "Main", bundle: nil)
             let sid: NSStoryboard.SceneIdentifier = "Accessory View Controller"
             guard let accessoryVC = storyboard.instantiateController(withIdentifier: sid) as? AccessoryViewController else {
-                preconditionFailure("Failed to instantiate AccessoryViewController")
+                NSSound.beep()
+                return false
             }
             self.accessoryVC = accessoryVC
             accessoryVC.loadView()
             accessoryVC.delegate = self
         }
-        guard let accessoryVC = self.accessoryVC else { preconditionFailure("Unexpected nil accessoryVC detected.") }
+        guard let accessoryVC = self.accessoryVC else { return false }
         
         // prepare file types same as current source
         var uti: String = self.fileType ?? AVFileType.mov.rawValue

--- a/cutter2/Document/Document+UI.swift
+++ b/cutter2/Document/Document+UI.swift
@@ -146,13 +146,14 @@ extension Document {
         let storyboard: NSStoryboard = NSStoryboard(name: "Main", bundle: nil)
         let sid: NSStoryboard.SceneIdentifier = "CAPARSheet Controller"
         guard let caparWC = storyboard.instantiateController(withIdentifier: sid) as? NSWindowController else {
-            preconditionFailure("Failed to instantiate CAPARSheet Controller")
+            NSSound.beep()
+            return
         }
         // caparWC.loadWindow()
         
         // Prepare CAPAR ViewController
-        guard let contVC = caparWC.contentViewController else { preconditionFailure("Unexpected nil contentViewController detected.") }
-        guard let caparVC = contVC as? CAPARViewController else { preconditionFailure("Unexpected nil CAPARViewController detected.") }
+        guard let contVC = caparWC.contentViewController else { NSSound.beep(); return }
+        guard let caparVC = contVC as? CAPARViewController else { NSSound.beep(); return }
         guard caparVC.applySource(dict) else { return }
         
         // Show CAPAR Sheet

--- a/cutter2/Document/Document.swift
+++ b/cutter2/Document/Document.swift
@@ -250,7 +250,9 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
                 self.movieMutator = MovieMutator(with: movie)
                 self.addMutationObserver()
             } else {
-                preconditionFailure("ERROR: Failed on AVMutableMovie()")
+                LoggingSystem.video.error("AVMutableMovie() returned nil")
+                NSSound.beep()
+                return
             }
         }
         
@@ -260,7 +262,8 @@ class Document: NSDocument, NSOpenSavePanelDelegate, AccessoryViewDelegate {
         // Instantiate and Register Window Controller
         let sid: NSStoryboard.SceneIdentifier = "Document Window Controller"
         guard let windowController = storyboard.instantiateController(withIdentifier: sid) as? WindowController else {
-            preconditionFailure("Failed to instantiate WindowController")
+            NSSound.beep()
+            return
         }
         self.addWindowController(windowController)
         

--- a/cutter2/Models/MovieMutator+Edit.swift
+++ b/cutter2/Models/MovieMutator+Edit.swift
@@ -31,7 +31,8 @@ extension MovieMutator {
         
         // Prepare clip
         guard let aClip = internalMovie.mutableCopy() as? AVMutableMovie else {
-            preconditionFailure("mutableCopy() of AVMutableMovie returned non-AVMutableMovie")
+            LoggingSystem.video.error("mutableCopy() of AVMutableMovie returned non-AVMutableMovie")
+            return nil
         }
         var clip = aClip
         if clip.timescale != range.duration.timescale {

--- a/cutter2/Models/MovieMutator+Player.swift
+++ b/cutter2/Models/MovieMutator+Player.swift
@@ -24,7 +24,8 @@ extension MovieMutator {
     /// - Throws: Errors thrown by async video-composition generation on macOS 15+.
     public func makePlayerItem() async throws -> AVPlayerItem {
         guard let asset = internalMovie.copy() as? AVAsset else {
-            preconditionFailure("copy() of AVMutableMovie returned non-AVAsset")
+            LoggingSystem.video.error("copy() of AVMutableMovie returned non-AVAsset")
+            throw CocoaError(.fileReadUnknown)
         }
         let playerItem: AVPlayerItem = AVPlayerItem(asset: asset)
         if let comp = try await makeVideoComposition(for: asset) {

--- a/cutter2/Models/MovieMutator+Transform.swift
+++ b/cutter2/Models/MovieMutator+Transform.swift
@@ -21,11 +21,17 @@ extension MovieMutator {
     
     //
     private func doReplace(_ movie: Data, _ range: CMTimeRange, _ time: CMTime) {
-        precondition(validateRange(range, false), "ERROR: invalid range")
+        guard validateRange(range, false) else {
+            LoggingSystem.video.error("invalid range in doReplace")
+            return
+        }
         
         // perform replacement
         do {
-            precondition(reloadMovie(from: movie), "ERROR: reloadMovie failed")
+            guard reloadMovie(from: movie) else {
+                LoggingSystem.video.error("reloadMovie failed in doReplace")
+                return
+            }
             
             // Update Marker
             let movie = internalMovie
@@ -38,7 +44,10 @@ extension MovieMutator {
     //
     private func undoReplace(_ data: Data, _ range: CMTimeRange, _ time: CMTime) {
         let reloadDone: Bool = reloadAndNotify(from: data, range: range, time: time)
-        precondition(reloadDone, "ERROR: reloadAndNotify failed")
+        guard reloadDone else {
+            LoggingSystem.video.error("reloadAndNotify failed in undoReplace")
+            return
+        }
     }
     
     //
@@ -130,7 +139,8 @@ extension MovieMutator {
         var count: Int = 0
         
         guard let movie = internalMovie.mutableCopy() as? AVMutableMovie else {
-            preconditionFailure("mutableCopy() of AVMutableMovie returned non-AVMutableMovie")
+            LoggingSystem.video.error("mutableCopy() of AVMutableMovie returned non-AVMutableMovie")
+            return false
         }
         
         let vTracks: [AVMutableMovieTrack] = movie.tracks(withMediaType: .video)

--- a/cutter2/Models/MovieWriter+ExportSession.swift
+++ b/cutter2/Models/MovieWriter+ExportSession.swift
@@ -347,7 +347,8 @@ extension MovieWriter {
     public func validateExportSession(fileType type: AVFileType, presetName preset: String?) async -> Bool {
         let preset: String = (preset ?? AVAssetExportPresetPassthrough)
         guard let movie = internalMovie.copy() as? AVAsset else {
-            preconditionFailure("copy() of AVMutableMovie returned non-AVAsset")
+            LoggingSystem.video.error("copy() of AVMutableMovie returned non-AVAsset")
+            return false
         }
         
         let compatible: Bool

--- a/cutter2/Views/TimelineView.swift
+++ b/cutter2/Views/TimelineView.swift
@@ -30,7 +30,8 @@ public extension NSBezierPath {
             case .quadraticCurveTo:
                 path.addQuadCurve(to: points[1], control: points[0])
             @unknown default:
-                preconditionFailure("Unknown NSBezierPath element type encountered")
+                NSSound.beep()
+                break
             }
         }
         return path


### PR DESCRIPTION
## Fix H-09: replace preconditionFailure/precondition with guard in 20 user-reachable code paths

Replace `preconditionFailure` / `precondition` with `guard` + graceful bail in 10 files (20 sites) to prevent user-reachable crashes during SaveAs, Export, cut/paste/delete, and inspector operations. `MovieMutatorBase.swift:20` (init invariant) is intentionally kept as `preconditionFailure` because early return would leave `internalMovie` uninitialized and cannot recover.

### Problem

User-facing code paths in `Document`, `MovieMutator`, and `TimelineView` contained 20 reachable `preconditionFailure` / `precondition` checks. `preconditionFailure` terminates the process like `fatalError`, so any runtime failure (storyboard wiring, teardown race, `mutableCopy()` / `copy()` type mismatch, invalid range, unknown bezier path element) caused an immediate crash while the user was actively working.

### Fix

| Category | Pattern | Rationale |
|---|---|---|
| Storyboard wiring failure in `@IBAction` paths | `guard let ... else { NSSound.beep(); return }` | S-10 pattern: notify user and bail gracefully. |
| Storyboard wiring failure in internal/teardown paths | `guard let ... else { return }` | Silent return is sufficient; user notification is not required. |
| `mutableCopy()` / `copy()` type checks | `guard let ... else { LoggingSystem.video.error(...); return }` | Internal invariant reached by user action; log and bail. |
| `precondition(validateRange, ...)` / `precondition(reloadMovie, ...)` | `guard <cond> else { LoggingSystem.video.error(...); return }` | Same rationale: log and bail. |
| `@unknown default` in `TimelineView` | `default { NSSound.beep(); break }` | Skip unknown path element instead of crashing. |

`MovieMutator+Player.swift:27` throws `CocoaError(.fileReadUnknown)` because the call site (`Document+UI.swift:282`) is already `try await` + `do-catch`. `.fileReadCorruptError` is not available in the current SDK, so `.fileReadUnknown` is used instead.

### Verification

- No `preconditionFailure` / `precondition` remains in the targeted user-reachable paths except `MovieMutatorBase.swift:20` (init exception).
- Xcode Build: SUCCEEDED
- Xcode Analyze: SUCCEEDED
- Xcode Test: SUCCEEDED

### References

- Plan: `/_plans/H-09_precondition_user_reachable_fix_plan.md` (v4)
- Backlog: `/_backlogs/cutter2_backlog.md` H-09
