### PR TITLE
test: add keyboard and timeline rendering coverage

### DIFF
--- a/cutter2/Views/TimelineView.swift
+++ b/cutter2/Views/TimelineView.swift
@@ -163,19 +163,19 @@ class TimelineView: NSView, CALayerDelegate {
     
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        self.wantsLayer = true
-
-        setupLabel()
-        setupSublayer()
-        needsUpdateTrackingArea = true
+        initializeLayers()
     }
 
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
+        initializeLayers()
+    }
+
+    private func initializeLayers() {
         self.wantsLayer = true
         
         setupLabel()
         setupSublayer()
-        needsUpdateTrackingArea = true // setupTrackingArea()
+        needsUpdateTrackingArea = true
     }
 }

--- a/cutter2/Views/TimelineView.swift
+++ b/cutter2/Views/TimelineView.swift
@@ -161,6 +161,15 @@ class TimelineView: NSView, CALayerDelegate {
     // MARK: - NSView methods
     /* ============================================ */
     
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.wantsLayer = true
+
+        setupLabel()
+        setupSublayer()
+        needsUpdateTrackingArea = true
+    }
+
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
         self.wantsLayer = true

--- a/cutter2Tests/TimelineViewRenderingTests.swift
+++ b/cutter2Tests/TimelineViewRenderingTests.swift
@@ -1,0 +1,164 @@
+//
+//  TimelineViewRenderingTests.swift
+//  cutter2Tests
+//
+
+import XCTest
+import Cocoa
+@testable import cutter2
+
+nonisolated(unsafe) private var timelineViewTestStorage: TimelineView?
+
+@MainActor
+final class TimelineViewRenderingTests: XCTestCase {
+    nonisolated(unsafe) private var timelineView: TimelineView!
+
+    override func setUp() {
+        super.setUp()
+        MainActor.assumeIsolated {
+            timelineViewTestStorage = TimelineView(frame: CGRect(x: 0, y: 0, width: 200, height: 50))
+        }
+        timelineView = timelineViewTestStorage
+    }
+
+    override func tearDown() {
+        timelineView = nil
+        timelineViewTestStorage = nil
+        super.tearDown()
+    }
+
+    func testPointOfPosition_CalculatesCorrectX() {
+        let point = timelineView.point(of: 0.5)
+        let width = timelineView.bounds.width - timelineView.leftMargin - timelineView.rightMargin
+        let expectedX = timelineView.leftMargin + width * 0.5
+
+        XCTAssertEqual(point.x, expectedX, accuracy: 0.001)
+        XCTAssertEqual(point.y, timelineView.bounds.height / 2.0, accuracy: 0.001)
+    }
+
+    func testPointOfPosition_AtZero_ReturnsLeftEdge() {
+        let point = timelineView.point(of: 0.0)
+
+        XCTAssertEqual(point.x, timelineView.leftMargin, accuracy: 0.001)
+        XCTAssertEqual(point.y, timelineView.bounds.height / 2.0, accuracy: 0.001)
+    }
+
+    func testPointOfPosition_AtOne_ReturnsRightEdge() {
+        let point = timelineView.point(of: 1.0)
+        let expectedX = timelineView.bounds.width - timelineView.rightMargin
+
+        XCTAssertEqual(point.x, expectedX, accuracy: 0.001)
+    }
+
+    func testPointOfPosition_OutOfRange_PreservesLinearMapping() {
+        let underflow = timelineView.point(of: -0.1)
+        let overflow = timelineView.point(of: 1.1)
+        let width = timelineView.bounds.width - timelineView.leftMargin - timelineView.rightMargin
+
+        XCTAssertEqual(underflow.x, timelineView.leftMargin - width * 0.1, accuracy: 0.001)
+        XCTAssertEqual(overflow.x, timelineView.leftMargin + width * 1.1, accuracy: 0.001)
+    }
+
+    func testUpdateTimeline_SameValues_ReturnsFalse() {
+        timelineView.currentPosition = 0.5
+        timelineView.startPosition = 0.2
+        timelineView.endPosition = 0.8
+        timelineView.isValid = true
+
+        let result = timelineView.updateTimeline(
+            current: 0.5,
+            from: 0.2,
+            to: 0.8,
+            isValid: true
+        )
+
+        XCTAssertFalse(result)
+    }
+
+    func testUpdateTimeline_NewValues_ReturnsTrue() {
+        timelineView.currentPosition = 0.5
+        timelineView.startPosition = 0.2
+        timelineView.endPosition = 0.8
+        timelineView.isValid = true
+
+        let result = timelineView.updateTimeline(
+            current: 0.6,
+            from: 0.3,
+            to: 0.9,
+            isValid: true
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    func testUpdateTimeline_NaN_ClearsState() {
+        timelineView.currentPosition = 0.5
+        timelineView.startPosition = 0.2
+        timelineView.endPosition = 0.8
+        timelineView.isValid = true
+
+        let result = timelineView.updateTimeline(
+            current: .nan,
+            from: .nan,
+            to: .nan,
+            isValid: true
+        )
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(timelineView.isValid)
+        XCTAssertEqual(timelineView.currentPosition, 0.0, accuracy: 0.001)
+        XCTAssertEqual(timelineView.startPosition, 0.0, accuracy: 0.001)
+        XCTAssertEqual(timelineView.endPosition, 0.0, accuracy: 0.001)
+    }
+
+    func testLayout_CurrentMarkerCentered() {
+        timelineView.currentPosition = 0.5
+        timelineView.layout()
+
+        guard let currentMarker = timelineView.currentMarker else {
+            return XCTFail("current marker layer should exist")
+        }
+
+        let expectedX = timelineView.point(of: 0.5).x - currentMarker.frame.width / 2.0
+        XCTAssertEqual(currentMarker.frame.midX, timelineView.point(of: 0.5).x, accuracy: 0.001)
+        XCTAssertEqual(currentMarker.frame.origin.x, expectedX, accuracy: 0.001)
+    }
+
+    func testLayout_SelectionWidthMatchesRange() {
+        timelineView.currentPosition = 0.5
+        timelineView.startPosition = 0.2
+        timelineView.endPosition = 0.8
+        timelineView.isValid = true
+        _ = timelineView.updateTimeline(current: 0.5, from: 0.2, to: 0.8, isValid: true)
+        timelineView.layout()
+
+        guard let selection = timelineView.selection else {
+            return XCTFail("selection layer should exist")
+        }
+
+        let expectedWidth = timelineView.point(of: 0.8).x - timelineView.point(of: 0.2).x
+        XCTAssertEqual(selection.frame.width, expectedWidth, accuracy: 1.0)
+    }
+
+    func testJKLMode_ChangesFillColorActive() {
+        timelineView.jklMode = false
+        let normalColor = timelineView.fillColorActive
+
+        timelineView.jklMode = true
+        let jklColor = timelineView.fillColorActive
+
+        XCTAssertNotEqual(normalColor, jklColor)
+        XCTAssertEqual(jklColor, NSColor.blue.cgColor)
+    }
+
+    func testSelectNewMarker_UpdatesStrokeAndFill() {
+        guard let currentMarker = timelineView.currentMarker else {
+            return XCTFail("current marker layer should exist")
+        }
+
+        XCTAssertTrue(timelineView.selectNewMarker(currentMarker))
+        XCTAssertEqual(timelineView.selectedMarker, currentMarker)
+        XCTAssertEqual(currentMarker.strokeColor, timelineView.strokeColorActive)
+        XCTAssertEqual(currentMarker.fillColor, timelineView.fillColorActive)
+    }
+}

--- a/cutter2Tests/TimelineViewRenderingTests.swift
+++ b/cutter2Tests/TimelineViewRenderingTests.swift
@@ -7,24 +7,18 @@ import XCTest
 import Cocoa
 @testable import cutter2
 
-nonisolated(unsafe) private var timelineViewTestStorage: TimelineView?
-
 @MainActor
 final class TimelineViewRenderingTests: XCTestCase {
-    nonisolated(unsafe) private var timelineView: TimelineView!
+    private var timelineView: TimelineView!
 
-    override func setUp() {
-        super.setUp()
-        MainActor.assumeIsolated {
-            timelineViewTestStorage = TimelineView(frame: CGRect(x: 0, y: 0, width: 200, height: 50))
-        }
-        timelineView = timelineViewTestStorage
+    override func setUp() async throws {
+        try await super.setUp()
+        timelineView = TimelineView(frame: CGRect(x: 0, y: 0, width: 200, height: 50))
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         timelineView = nil
-        timelineViewTestStorage = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testPointOfPosition_CalculatesCorrectX() {

--- a/cutter2Tests/ViewControllerKeyEventTests.swift
+++ b/cutter2Tests/ViewControllerKeyEventTests.swift
@@ -7,9 +7,6 @@ import XCTest
 import AVFoundation
 @testable import cutter2
 
-nonisolated(unsafe) private var viewControllerTestStorage: ViewController?
-nonisolated(unsafe) private var delegateTestStorage: MockViewControllerDelegate?
-
 @MainActor
 private final class MockViewControllerDelegate: ViewControllerDelegate {
     var setRateCalls: [Int] = []
@@ -80,26 +77,20 @@ private final class MockViewControllerDelegate: ViewControllerDelegate {
 
 @MainActor
 final class ViewControllerKeyEventTests: XCTestCase {
-    nonisolated(unsafe) private var viewController: ViewController!
-    nonisolated(unsafe) private var mockDelegate: MockViewControllerDelegate!
+    private var viewController: ViewController!
+    private var mockDelegate: MockViewControllerDelegate!
 
-    override func setUp() {
-        super.setUp()
-        MainActor.assumeIsolated {
-            viewControllerTestStorage = ViewController(nibName: nil, bundle: nil)
-            delegateTestStorage = MockViewControllerDelegate()
-            viewControllerTestStorage?.delegate = delegateTestStorage
-        }
-        viewController = viewControllerTestStorage
-        mockDelegate = delegateTestStorage
+    override func setUp() async throws {
+        try await super.setUp()
+        viewController = ViewController(nibName: nil, bundle: nil)
+        mockDelegate = MockViewControllerDelegate()
+        viewController.delegate = mockDelegate
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         viewController = nil
         mockDelegate = nil
-        viewControllerTestStorage = nil
-        delegateTestStorage = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     private func event(
@@ -150,7 +141,7 @@ final class ViewControllerKeyEventTests: XCTestCase {
         XCTAssertEqual(mockDelegate.togglePlayCalls, 1)
     }
 
-    func testJKLMode_IJK_Combo_CallsSetSlow() {
+    func testJKLMode_JK_Combo_CallsSetSlow() {
         viewController.mimicJKLcombination = true
         viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
         viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))

--- a/cutter2Tests/ViewControllerKeyEventTests.swift
+++ b/cutter2Tests/ViewControllerKeyEventTests.swift
@@ -1,0 +1,241 @@
+//
+//  ViewControllerKeyEventTests.swift
+//  cutter2Tests
+//
+
+import XCTest
+import AVFoundation
+@testable import cutter2
+
+nonisolated(unsafe) private var viewControllerTestStorage: ViewController?
+nonisolated(unsafe) private var delegateTestStorage: MockViewControllerDelegate?
+
+@MainActor
+private final class MockViewControllerDelegate: ViewControllerDelegate {
+    var setRateCalls: [Int] = []
+    var setSlowCalls: [Float] = []
+    var togglePlayCalls = 0
+    var stepByCountCalls: [(count: Int64, resetStart: Bool, resetEnd: Bool)] = []
+    var stepBySecondCalls: [(offset: Float64, resetStart: Bool, resetEnd: Bool)] = []
+    var setStartCalls: [anchor] = []
+    var setEndCalls: [anchor] = []
+    var setCurrentCalls: [anchor] = []
+
+    func hasSelection() -> Bool { false }
+    func hasDuration() -> Bool { false }
+    func hasClipOnPBoard() -> Bool { false }
+    func debugInfo() {}
+    func timeOfPosition(_ percentage: Float64) -> CMTime { .zero }
+    func positionOfTime(_ time: CMTime) -> Float64 { 0.0 }
+    func doCut() throws {}
+    func doCopy() throws {}
+    func doPaste() throws {}
+    func doDelete() throws {}
+    func selectAll() {}
+
+    func doStepByCount(_ count: Int64, _ resetStart: Bool, _ resetEnd: Bool) {
+        stepByCountCalls.append((count, resetStart, resetEnd))
+    }
+
+    func doStepBySecond(_ offset: Float64, _ resetStart: Bool, _ resetEnd: Bool) {
+        stepBySecondCalls.append((offset, resetStart, resetEnd))
+    }
+
+    func doVolumeOffset(_ percent: Int) {}
+    func doMoveLeft(_ optFlag: Bool, _ shiftFlag: Bool, _ resetStart: Bool, _ resetEnd: Bool) {}
+    func doMoveRight(_ optFlag: Bool, _ shiftFlag: Bool, _ resetStart: Bool, _ resetEnd: Bool) {}
+
+    func doSetSlow(_ ratio: Float) {
+        setSlowCalls.append(ratio)
+    }
+
+    func doSetRate(_ offset: Int) {
+        setRateCalls.append(offset)
+    }
+
+    func doTogglePlay() {
+        togglePlayCalls += 1
+    }
+
+    func didUpdateCursor(to position: Float64) {}
+    func didUpdateStart(to position: Float64) {}
+    func didUpdateEnd(to position: Float64) {}
+    func didUpdateSelection(from fromPos: Float64, to toPos: Float64) {}
+    func presentationInfo(at position: Float64) -> PresentationInfo? { nil }
+    func previousInfo(of range: CMTimeRange) -> PresentationInfo? { nil }
+    func nextInfo(of range: CMTimeRange) -> PresentationInfo? { nil }
+
+    func doSetCurrent(to goTo: anchor) {
+        setCurrentCalls.append(goTo)
+    }
+
+    func doSetStart(to goTo: anchor) {
+        setStartCalls.append(goTo)
+    }
+
+    func doSetEnd(to goTo: anchor) {
+        setEndCalls.append(goTo)
+    }
+}
+
+@MainActor
+final class ViewControllerKeyEventTests: XCTestCase {
+    nonisolated(unsafe) private var viewController: ViewController!
+    nonisolated(unsafe) private var mockDelegate: MockViewControllerDelegate!
+
+    override func setUp() {
+        super.setUp()
+        MainActor.assumeIsolated {
+            viewControllerTestStorage = ViewController(nibName: nil, bundle: nil)
+            delegateTestStorage = MockViewControllerDelegate()
+            viewControllerTestStorage?.delegate = delegateTestStorage
+        }
+        viewController = viewControllerTestStorage
+        mockDelegate = delegateTestStorage
+    }
+
+    override func tearDown() {
+        viewController = nil
+        mockDelegate = nil
+        viewControllerTestStorage = nil
+        delegateTestStorage = nil
+        super.tearDown()
+    }
+
+    private func event(
+        type: NSEvent.EventType = .keyDown,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags = [],
+        characters: String
+    ) -> NSEvent {
+        NSEvent.keyEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0.0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+    }
+
+    func testJKLMode_J_NoModifier_CallsSetRate() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
+
+        XCTAssertEqual(mockDelegate.setRateCalls, [-1])
+    }
+
+    func testJKLMode_K_NoModifier_CallsSetRate() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+
+        XCTAssertEqual(mockDelegate.setRateCalls, [0])
+    }
+
+    func testJKLMode_L_NoModifier_CallsSetRate() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x25, characters: "l"))
+
+        XCTAssertEqual(mockDelegate.setRateCalls, [1])
+    }
+
+    func testJKLMode_Space_NoModifier_CallsTogglePlay() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x31, characters: " "))
+
+        XCTAssertEqual(mockDelegate.togglePlayCalls, 1)
+    }
+
+    func testJKLMode_IJK_Combo_CallsSetSlow() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+
+        XCTAssertEqual(mockDelegate.setSlowCalls, [-0.5])
+    }
+
+    func testJKLMode_LK_Combo_CallsSetSlow() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x25, characters: "l"))
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+
+        XCTAssertEqual(mockDelegate.setSlowCalls, [0.5])
+    }
+
+    func testJKLMode_KeyUpK_AfterJK_CallsSetRate() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+        viewController.keyUp(with: event(type: .keyUp, keyCode: 0x28, characters: ""))
+
+        XCTAssertEqual(mockDelegate.setRateCalls, [-1, -1])
+    }
+
+    func testJKLMode_J_WithOptionShift_AfterJK_CallsStepBySecond() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+        viewController.keyDown(with: event(
+            keyCode: 0x26,
+            modifiers: [.option, .shift],
+            characters: "j"
+        ))
+
+        XCTAssertEqual(mockDelegate.stepBySecondCalls.count, 1)
+        XCTAssertEqual(mockDelegate.stepBySecondCalls[0].offset, -viewController.offsetM, accuracy: 0.001)
+        XCTAssertFalse(mockDelegate.stepBySecondCalls[0].resetStart)
+        XCTAssertFalse(mockDelegate.stepBySecondCalls[0].resetEnd)
+    }
+
+    func testJKLMode_I_NoModifier_SetsStart() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x22, characters: "i"))
+
+        XCTAssertEqual(mockDelegate.setStartCalls.count, 1)
+        XCTAssertEqual(mockDelegate.setStartCalls[0], .current)
+    }
+
+    func testJKLMode_O_NoModifier_SetsEnd() {
+        viewController.mimicJKLcombination = true
+        viewController.keyDown(with: event(keyCode: 0x1f, characters: "o"))
+
+        XCTAssertEqual(mockDelegate.setEndCalls.count, 1)
+        XCTAssertEqual(mockDelegate.setEndCalls[0], .current)
+    }
+
+    func testStepMode_J_NoModifier_CallsStepBySecond() {
+        viewController.mimicJKLcombination = false
+        viewController.keyDown(with: event(keyCode: 0x26, characters: "j"))
+
+        XCTAssertEqual(mockDelegate.stepBySecondCalls.count, 1)
+        XCTAssertEqual(mockDelegate.stepBySecondCalls[0].offset, -viewController.offsetL, accuracy: 0.001)
+    }
+
+    func testStepMode_K_NoModifier_CallsStepBySecond() {
+        viewController.mimicJKLcombination = false
+        viewController.keyDown(with: event(keyCode: 0x28, characters: "k"))
+
+        XCTAssertEqual(mockDelegate.stepBySecondCalls.count, 1)
+        XCTAssertEqual(mockDelegate.stepBySecondCalls[0].offset, -viewController.offsetS, accuracy: 0.001)
+    }
+
+    func testStepMode_L_NoModifier_CallsStepBySecond() {
+        viewController.mimicJKLcombination = false
+        viewController.keyDown(with: event(keyCode: 0x25, characters: "l"))
+
+        XCTAssertEqual(mockDelegate.stepBySecondCalls.count, 1)
+        XCTAssertEqual(mockDelegate.stepBySecondCalls[0].offset, viewController.offsetS, accuracy: 0.001)
+    }
+
+    func testStepMode_Semicolon_NoModifier_CallsStepBySecond() {
+        viewController.mimicJKLcombination = false
+        viewController.keyDown(with: event(keyCode: 0x29, characters: ";"))
+
+        XCTAssertEqual(mockDelegate.stepBySecondCalls.count, 1)
+        XCTAssertEqual(mockDelegate.stepBySecondCalls[0].offset, viewController.offsetL, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
Adds focused keyboard routing and TimelineView rendering-structure coverage for cutter2. The tests exercise the existing delegate contracts and layer geometry without introducing an XCUITest target or pixel-based snapshots.

### Changes

- Add 14 ViewController keyboard event tests covering JKL mode, step mode, modifiers, key-up state transitions, playback, and I/O marker commands.
- Add 11 TimelineView tests covering coordinate mapping, state updates, NaN clearing, layout geometry, marker selection, and mode colors.
- Add a programmatic `TimelineView(frame:)` initializer and share layer setup between frame and coder initialization paths.

### Verification

- Targeted T-10/T-11 tests: passed.
- Clean `build-for-testing`: passed.
- Full test suite: 190 tests passed.
