### PR TITLE
test(T-14): add Document read error and TimelineView mouse input tests

### DIFF
--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -54,7 +54,10 @@ extension Document {
     /// Shared by `readAsync(from:openPreparation:)` and `read(from:ofType:)` so the
     /// UTI check has a single source of truth (and is directly testable).
     /// - Parameter typeName: The UTI to validate.
-    /// - Throws: `DocumentError.incompatibleFileType` if the UTI is not a movie type.
+    /// - Throws: An `NSError` produced by `ErrorUtilities.throwError` for
+    ///   `DocumentError.incompatibleFileType` (domain `NSOSStatusErrorDomain`, code
+    ///   `unimpErr`) when the UTI is not a movie type. Note the thrown value is the
+    ///   NSError form, not the `DocumentError` case itself.
     nonisolated static func validateMovieType(_ typeName: String) throws {
         let fileType = AVFileType.init(rawValue: typeName)
         guard AVMovie.movieTypes().contains(fileType) else {

--- a/cutter2/Document/Document+FileIO.swift
+++ b/cutter2/Document/Document+FileIO.swift
@@ -46,6 +46,25 @@ extension Document {
     }
     
     /* ============================================ */
+    // MARK: - File type validation
+    /* ============================================ */
+    
+    /// Validate that the given UTI is a supported movie type.
+    ///
+    /// Shared by `readAsync(from:openPreparation:)` and `read(from:ofType:)` so the
+    /// UTI check has a single source of truth (and is directly testable).
+    /// - Parameter typeName: The UTI to validate.
+    /// - Throws: `DocumentError.incompatibleFileType` if the UTI is not a movie type.
+    nonisolated static func validateMovieType(_ typeName: String) throws {
+        let fileType = AVFileType.init(rawValue: typeName)
+        guard AVMovie.movieTypes().contains(fileType) else {
+            let reason = "(UTI: \(typeName))"
+            LoggingSystem.fileIO.error("Incompatible file type: \(typeName)")
+            try ErrorUtilities.throwError(DocumentError.incompatibleFileType, reason: reason)
+        }
+    }
+    
+    /* ============================================ */
     // MARK: - Read
     /* ============================================ */
     
@@ -57,13 +76,7 @@ extension Document {
         LoggingSystem.fileIO.info("Reading document from \(url.lastPathComponent, privacy: .public)")
         
         // Check UTI for AVMovie fileType
-        let typeName = openPreparation.typeName
-        let fileType = AVFileType.init(rawValue: typeName)
-        if AVMovie.movieTypes().contains(fileType) == false {
-            let reason = "(UTI: \(typeName))"
-            LoggingSystem.fileIO.error("Incompatible file type: \(typeName)")
-            try throwError(.incompatibleFileType, reason: reason)
-        }
+        try Self.validateMovieType(openPreparation.typeName)
         
         if let header = openPreparation.movHeader {
             // File opened successfully
@@ -94,12 +107,7 @@ extension Document {
         // 3) apply the new mutator on the MainActor
         
         // Stage 0: Validate the AppKit-provided UTI before doing any I/O.
-        let fileType = AVFileType.init(rawValue: typeName)
-        guard AVMovie.movieTypes().contains(fileType) else {
-            let reason = "(UTI: \(typeName))"
-            LoggingSystem.fileIO.error("Incompatible file type: \(typeName)")
-            try throwError(.incompatibleFileType, reason: reason)
-        }
+        try Self.validateMovieType(typeName)
         
         // Stage 1: File I/O is performed on a background task and bridged back
         // through AsyncBridge.

--- a/cutter2Tests/DocumentTests.swift
+++ b/cutter2Tests/DocumentTests.swift
@@ -54,16 +54,14 @@ final class DocumentTests: XCTestCase {
         XCTAssertNoThrow(try Document.validateMovieType("com.apple.quicktime-movie"))
     }
     
-    /// トラックを含まない無効な movHeader から生成した AVMutableMovie が
-    /// `MovieHeaderValidator.isValid` で false になることを検証。
+    /// トラックを含まない AVMutableMovie が `MovieHeaderValidator.isValid` で false になることを検証。
     /// `readAsync` のヘッダー検証は `MovieHeaderValidator.isValid` に委譲しているため、
     /// ヘッダー検証エラー経路（`.unableToOpenFile` 相当）を直接テストする。
     ///
-    /// 注: `AVMutableMovie(data:)` は空データ（length 0）を NSInvalidArgumentException で拒否するため、
-    /// トラックを含まない非ゼロ長のダミーデータを使用する。
-    func testInvalidHeaderFailsValidation() {
-        let dummyHeader = Data([0x00, 0x00, 0x00, 0x00]) // 非ゼロ長・トラックなし
-        let movie = AVMutableMovie(data: dummyHeader)
+    /// 注: `AVMutableMovie()`（引数なし）でトラックなしの movie を安全に構築する。
+    /// `AVMutableMovie(data:)` に任意バイト列を渡すと AVFoundation が例外を上げるリスクがあるため使用しない。
+    func testInvalidHeaderFailsValidation() throws {
+        let movie = AVMutableMovie() // 引数なし → トラックなしの movie を生成
         XCTAssertFalse(MovieHeaderValidator.isValid(movie))
         if let error = MovieHeaderValidator.validate(movie) {
             guard case .noTracks = error else {

--- a/cutter2Tests/DocumentTests.swift
+++ b/cutter2Tests/DocumentTests.swift
@@ -33,8 +33,49 @@ final class DocumentTests: XCTestCase {
         XCTAssertTrue(types.contains("com.apple.quicktime-movie"))
     }
     
-    // MARK: - DocumentError Tests
+    // MARK: - Document read error handling (T-14)
     
+    /// `validateMovieType` が不正な UTI で `incompatibleFileType` をスローすることを検証。
+    /// `Document()` 直接生成は `windowControllers[0]` アクセス（NSRangeException）でクラッシュするため、
+    /// `readAsync` の UTI 検証ロジック（`Self.validateMovieType`）を分離してテストする。
+    ///
+    /// 注: `ErrorUtilities.throwError` は `DocumentError` を `NSError` に変換して throw する。
+    /// `DocumentError.incompatibleFileType` は `NSOSStatusErrorDomain` / `unimpErr` (-4) にマップされる。
+    func testValidateMovieTypeRejectsInvalidUTI() throws {
+        XCTAssertThrowsError(try Document.validateMovieType("invalid.type")) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, NSOSStatusErrorDomain)
+            XCTAssertEqual(nsError.code, unimpErr)
+        }
+    }
+    
+    /// `validateMovieType` が有効な movie UTI を許可することを検証。
+    func testValidateMovieTypeAcceptsMovieUTI() throws {
+        XCTAssertNoThrow(try Document.validateMovieType("com.apple.quicktime-movie"))
+    }
+    
+    /// トラックを含まない無効な movHeader から生成した AVMutableMovie が
+    /// `MovieHeaderValidator.isValid` で false になることを検証。
+    /// `readAsync` のヘッダー検証は `MovieHeaderValidator.isValid` に委譲しているため、
+    /// ヘッダー検証エラー経路（`.unableToOpenFile` 相当）を直接テストする。
+    ///
+    /// 注: `AVMutableMovie(data:)` は空データ（length 0）を NSInvalidArgumentException で拒否するため、
+    /// トラックを含まない非ゼロ長のダミーデータを使用する。
+    func testInvalidHeaderFailsValidation() {
+        let dummyHeader = Data([0x00, 0x00, 0x00, 0x00]) // 非ゼロ長・トラックなし
+        let movie = AVMutableMovie(data: dummyHeader)
+        XCTAssertFalse(MovieHeaderValidator.isValid(movie))
+        if let error = MovieHeaderValidator.validate(movie) {
+            guard case .noTracks = error else {
+                return XCTFail("Unexpected validation error: \(error)")
+            }
+        } else {
+            XCTFail("Expected noTracks validation error for track-less movie")
+        }
+    }
+
+    // MARK: - DocumentError Tests
+
     func testDocumentErrorTypes() throws {
         enum TestDocumentError: NSErrorConvertible {
             case testError

--- a/cutter2Tests/TimelineViewRenderingTests.swift
+++ b/cutter2Tests/TimelineViewRenderingTests.swift
@@ -5,6 +5,7 @@
 
 import XCTest
 import Cocoa
+import AVFoundation
 @testable import cutter2
 
 @MainActor
@@ -154,5 +155,139 @@ final class TimelineViewRenderingTests: XCTestCase {
         XCTAssertEqual(timelineView.selectedMarker, currentMarker)
         XCTAssertEqual(currentMarker.strokeColor, timelineView.strokeColorActive)
         XCTAssertEqual(currentMarker.fillColor, timelineView.fillColorActive)
+    }
+
+    // MARK: - TimelineView mouse input (T-14)
+
+    /// Mock delegate for TimelineView mouse input tests
+    @MainActor
+    private final class MockTimelineDelegate: TimelineUpdateDelegate {
+        var cursorUpdates: [Float64] = []
+        var startUpdates: [Float64] = []
+        var endUpdates: [Float64] = []
+        var selectionUpdates: [(Float64, Float64)] = []
+        var currentRequests: [anchor] = []
+        var startRequests: [anchor] = []
+        var endRequests: [anchor] = []
+        var presentationInfoValue: PresentationInfo? = nil
+
+        func didUpdateCursor(to position: Float64) { cursorUpdates.append(position) }
+        func didUpdateStart(to position: Float64) { startUpdates.append(position) }
+        func didUpdateEnd(to position: Float64) { endUpdates.append(position) }
+        func didUpdateSelection(from fromPos: Float64, to toPos: Float64) {
+            selectionUpdates.append((fromPos, toPos))
+        }
+        func presentationInfo(at position: Float64) -> PresentationInfo? { return presentationInfoValue }
+        func previousInfo(of range: CMTimeRange) -> PresentationInfo? { return nil }
+        func nextInfo(of range: CMTimeRange) -> PresentationInfo? { return nil }
+        func doSetCurrent(to goTo: anchor) { currentRequests.append(goTo) }
+        func doSetStart(to goTo: anchor) { startRequests.append(goTo) }
+        func doSetEnd(to goTo: anchor) { endRequests.append(goTo) }
+    }
+
+    /// mouseDown で startMarker クリック → selectNewMarker(true) + resetCurrent が doSetCurrent を呼ぶ
+    func testSelectNewMarkerOnStartRequestsCurrent() throws {
+        timelineView.layout()
+        let delegate = MockTimelineDelegate()
+        timelineView.delegate = delegate
+
+        let window = NSWindow(contentRect: timelineView.bounds, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = timelineView
+
+        guard let startMarker = timelineView.startMarker else {
+            return XCTFail("start marker should exist")
+        }
+
+        let hitPoint = CGPoint(
+            x: startMarker.frame.midX,
+            y: startMarker.frame.midY
+        )
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: hitPoint,
+            modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber,
+            context: nil, eventNumber: 1, clickCount: 1, pressure: 1
+        )!
+        timelineView.mouseDown(with: event)
+
+        XCTAssertEqual(delegate.currentRequests, [.start], "doSetCurrent(.start) should be called when clicking start marker")
+    }
+
+    /// 選択済み startMarker をドラッグ → startPosition が更新され delegate に通知
+    func testMouseDraggedUpdatesStartPosition() throws {
+        timelineView.layout()
+        timelineView.isValid = true
+        timelineView.endPosition = 0.8 // Prevent selection update (start < end after drag)
+        let delegate = MockTimelineDelegate()
+        timelineView.delegate = delegate
+
+        guard let startMarker = timelineView.startMarker else {
+            return XCTFail("start marker should exist")
+        }
+        timelineView.selectedMarker = startMarker
+
+        let window = NSWindow(contentRect: timelineView.bounds, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = timelineView
+
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: CGPoint(x: 131.5, y: timelineView.bounds.midY),
+            modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber,
+            context: nil, eventNumber: 1, clickCount: 1, pressure: 1
+        )!
+        timelineView.mouseDragged(with: event)
+
+        XCTAssertFalse(delegate.startUpdates.isEmpty, "didUpdateStart should be called when dragging start marker")
+        XCTAssertEqual(timelineView.startPosition, 0.5, accuracy: 0.01)
+    }
+
+    /// 選択済み currentMarker をドラッグ → currentPosition が更新され delegate に通知
+    func testMouseDraggedUpdatesCurrentPosition() throws {
+        timelineView.layout()
+        timelineView.isValid = true
+        let delegate = MockTimelineDelegate()
+        timelineView.delegate = delegate
+
+        guard let currentMarker = timelineView.currentMarker else {
+            return XCTFail("current marker should exist")
+        }
+        timelineView.selectedMarker = currentMarker
+
+        let window = NSWindow(contentRect: timelineView.bounds, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = timelineView
+
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: CGPoint(x: 131.5, y: timelineView.bounds.midY),
+            modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber,
+            context: nil, eventNumber: 1, clickCount: 1, pressure: 1
+        )!
+        timelineView.mouseDragged(with: event)
+
+        XCTAssertFalse(delegate.cursorUpdates.isEmpty, "didUpdateCursor should be called when dragging current marker")
+        XCTAssertEqual(timelineView.currentPosition, 0.5, accuracy: 0.01)
+    }
+
+    /// selectedMarker が nil のとき mouseDragged は何もしない
+    func testMouseDraggedDoesNothingWhenNoSelection() throws {
+        timelineView.layout()
+        timelineView.isValid = true
+        timelineView.currentPosition = 0.0
+
+        let delegate = MockTimelineDelegate()
+        timelineView.delegate = delegate
+
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: CGPoint(x: 100, y: 25),
+            modifierFlags: [], timestamp: 0, windowNumber: 0,
+            context: nil, eventNumber: 1, clickCount: 1, pressure: 1
+        )!
+        timelineView.mouseDragged(with: event)
+
+        XCTAssertTrue(delegate.cursorUpdates.isEmpty)
+        XCTAssertTrue(delegate.startUpdates.isEmpty)
+        XCTAssertTrue(delegate.endUpdates.isEmpty)
+        XCTAssertEqual(timelineView.currentPosition, 0.0, accuracy: 0.001)
     }
 }


### PR DESCRIPTION
## Summary

Adds test coverage for the two remaining untested areas flagged by the codebase review: the Document read error paths (`incompatibleFileType` / header validation) and the TimelineView mouse input state transitions (`mouseDown` / `mouseDragged`). No behavioral changes — the single production-code edit extracts the duplicated UTI check into a shared, directly testable static function.

## Changes

- **cutter2/Document/Document+FileIO.swift**: Extract the UTI validation duplicated in `readAsync(from:openPreparation:)` and `read(from:ofType:)` into `nonisolated static func validateMovieType(_:)` (single source of truth, behavior unchanged — `Document.throwError` is a thin wrapper over `ErrorUtilities.throwError`).
- **cutter2Tests/DocumentTests.swift** (+3 tests): `testValidateMovieTypeRejectsInvalidUTI`, `testValidateMovieTypeAcceptsMovieUTI`, `testInvalidHeaderFailsValidation`. Tests the Document read error paths **without constructing a `Document` instance** — direct `Document()` init crashes in the test environment with `NSRangeException` because the `window` property force-indexes `windowControllers[0]` on an empty array (applies to full-suite runs as well).
- **cutter2Tests/TimelineViewRenderingTests.swift** (+4 tests): `testSelectNewMarkerOnStartRequestsCurrent` (mouseDown hit-test via `startMarker.frame` coordinates → `doSetCurrent(.start)`), `testMouseDraggedUpdatesStartPosition` / `testMouseDraggedUpdatesCurrentPosition` (drag to x=131.5 → position 0.5, delegate notified), `testMouseDraggedDoesNothingWhenNoSelection`. Adds a `@MainActor` mock delegate implementing all 10 `TimelineUpdateDelegate` methods.

## Verification

- `xcodebuild clean build`: SUCCEEDED (no warnings)
- `xcodebuild analyze`: SUCCEEDED (no warnings)
- `xcodebuild build-for-testing`: SUCCEEDED (test target, no warnings)
- `xcodebuild test-without-building`: full suite **196 tests pass, 0 failures** (T-14 adds 7 tests; no regressions)
- `git diff --stat -- cutter2/` limited to the `validateMovieType` extraction
